### PR TITLE
Fix live transcript rendering by Whisper segment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,11 @@ Errors should be visible. Silent failure is worse than a crash.
 
 - Use pytest.
 - Test behavior, not implementation details.
+- Prefer testing private helpers through public behavior. Private functions and methods are
+  implementation details, and direct tests for them often make refactoring harder.
+- If a private helper feels important enough to test directly, first consider whether the
+  responsibility should be extracted into a public collaborator or whether the public
+  behavior test is missing an important case.
 - Prefer concise names such as `test_<subject>_<expected_behavior>_when_<condition>`.
 - Use Arrange-Act-Assert structure for longer tests.
 - Add tests for:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meeting-minutes"
-version = "0.1.1"
+version = "0.1.2"
 description = "Local realtime transcription and meeting minutes CLI"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/meeting_minutes/__init__.py
+++ b/src/meeting_minutes/__init__.py
@@ -1,3 +1,3 @@
 """Local realtime transcription and meeting minutes CLI."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -22,6 +22,10 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
+def _segment_elapsed_seconds(chunk_start_seconds: int, segment_end: float) -> int:
+    return int(chunk_start_seconds + segment_end + 0.5)
+
+
 def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
     started_at = datetime.now()
     input_device = resolve_input_device(config.audio.device, config.audio.device_index)
@@ -56,7 +60,7 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
             if not dedupe.should_keep(text):
                 continue
             for segment in segments:
-                segment_elapsed = int(chunk_start_seconds + segment.end)
+                segment_elapsed = _segment_elapsed_seconds(chunk_start_seconds, segment.end)
                 stamp = format_elapsed(segment_elapsed)
                 console.print(f"[cyan][{stamp}][/cyan] {segment.text}")
                 if transcript_path is not None:

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -49,14 +49,18 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
             channels=config.audio.channels,
             chunk_seconds=config.audio.chunk_seconds,
         ):
+            chunk_start_seconds = elapsed_seconds
             elapsed_seconds += config.audio.chunk_seconds
-            text = transcriber.transcribe(chunk)
+            segments = transcriber.transcribe_segments(chunk)
+            text = " ".join(segment.text for segment in segments).strip()
             if not dedupe.should_keep(text):
                 continue
-            stamp = format_elapsed(elapsed_seconds)
-            console.print(f"[cyan][{stamp}][/cyan] {text}")
-            if transcript_path is not None:
-                append_transcript(transcript_path, elapsed_seconds, text)
+            for segment in segments:
+                segment_elapsed = int(chunk_start_seconds + segment.end)
+                stamp = format_elapsed(segment_elapsed)
+                console.print(f"[cyan][{stamp}][/cyan] {segment.text}")
+                if transcript_path is not None:
+                    append_transcript(transcript_path, segment_elapsed, segment.text)
 
             if (
                 next_draft_at is not None

--- a/src/meeting_minutes/transcribe.py
+++ b/src/meeting_minutes/transcribe.py
@@ -1,7 +1,16 @@
+from dataclasses import dataclass
+
 import numpy as np
 
 from meeting_minutes.config import TranscriptionConfig
 from meeting_minutes.errors import TranscriptionError
+
+
+@dataclass(frozen=True)
+class TranscriptionSegment:
+    start: float
+    end: float
+    text: str
 
 
 class WhisperTranscriber:
@@ -19,6 +28,9 @@ class WhisperTranscriber:
         self._language = config.language
 
     def transcribe(self, audio: np.ndarray) -> str:
+        return " ".join(segment.text for segment in self.transcribe_segments(audio)).strip()
+
+    def transcribe_segments(self, audio: np.ndarray) -> list[TranscriptionSegment]:
         try:
             segments, _info = self._model.transcribe(
                 audio,
@@ -26,7 +38,15 @@ class WhisperTranscriber:
                 vad_filter=True,
                 beam_size=1,
             )
-            texts = [segment.text.strip() for segment in segments if segment.text.strip()]
+            results = [
+                TranscriptionSegment(
+                    start=float(segment.start),
+                    end=float(segment.end),
+                    text=text,
+                )
+                for segment in segments
+                if (text := segment.text.strip())
+            ]
         except (RuntimeError, ValueError) as exc:
             raise TranscriptionError(f"文字起こしに失敗しました: {exc}") from exc
-        return " ".join(texts).strip()
+        return results

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,7 @@
+from meeting_minutes.live import _segment_elapsed_seconds
+
+
+def test_segment_elapsed_seconds_rounds_fractional_segment_end_to_nearest_second() -> None:
+    assert _segment_elapsed_seconds(10, 0.4) == 10
+    assert _segment_elapsed_seconds(10, 0.5) == 11
+    assert _segment_elapsed_seconds(10, 0.9) == 11

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,7 +1,47 @@
-from meeting_minutes.live import _segment_elapsed_seconds
+from collections.abc import Iterator
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from meeting_minutes.config import AppConfig, AudioConfig, OutputConfig
+from meeting_minutes.devices import InputDevice
+from meeting_minutes.live import run_live
+from meeting_minutes.transcribe import TranscriptionSegment
 
 
-def test_segment_elapsed_seconds_rounds_fractional_segment_end_to_nearest_second() -> None:
-    assert _segment_elapsed_seconds(10, 0.4) == 10
-    assert _segment_elapsed_seconds(10, 0.5) == 11
-    assert _segment_elapsed_seconds(10, 0.9) == 11
+def test_run_live_rounds_segment_timestamp_to_nearest_second(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_device = InputDevice(
+        index=1,
+        name="Mic",
+        channels=1,
+        default_sample_rate=16000,
+        is_blackhole=False,
+    )
+
+    def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
+        yield np.zeros(16000, dtype=np.float32)
+
+    class FakeTranscriber:
+        def __init__(self, _config: object) -> None:
+            pass
+
+        def transcribe_segments(self, _chunk: np.ndarray) -> list[TranscriptionSegment]:
+            return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
+
+    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
+    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
+    monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
+
+    run_live(
+        AppConfig(
+            audio=AudioConfig(chunk_seconds=1),
+            output=OutputConfig(base_dir=tmp_path),
+        )
+    )
+
+    transcript = next(tmp_path.glob("*/transcript_live.md")).read_text(encoding="utf-8")
+    assert "[00:00:01] hello" in transcript

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from meeting_minutes.config import TranscriptionConfig
+from meeting_minutes.transcribe import WhisperTranscriber
+
+
+class FakeWhisperSegment:
+    def __init__(self, start: float, end: float, text: str) -> None:
+        self.start = start
+        self.end = end
+        self.text = text
+
+
+class FakeWhisperModel:
+    def transcribe(
+        self,
+        audio: np.ndarray,
+        **kwargs: object,
+    ) -> tuple[list[FakeWhisperSegment], None]:
+        assert audio.dtype == np.float32
+        assert kwargs["language"] == "ja"
+        return (
+            [
+                FakeWhisperSegment(0.2, 1.0, " こんにちは "),
+                FakeWhisperSegment(1.4, 2.0, ""),
+                FakeWhisperSegment(2.1, 3.0, "お願いします"),
+            ],
+            None,
+        )
+
+
+def test_transcribe_segments_preserves_segment_times() -> None:
+    transcriber = WhisperTranscriber.__new__(WhisperTranscriber)
+    transcriber._model = FakeWhisperModel()
+    transcriber._language = "ja"
+
+    segments = transcriber.transcribe_segments(np.zeros(16000, dtype=np.float32))
+
+    assert [(segment.start, segment.end, segment.text) for segment in segments] == [
+        (0.2, 1.0, "こんにちは"),
+        (2.1, 3.0, "お願いします"),
+    ]
+
+
+def test_transcribe_keeps_joined_text_compatibility() -> None:
+    transcriber = WhisperTranscriber.__new__(WhisperTranscriber)
+    transcriber._model = FakeWhisperModel()
+    transcriber._language = TranscriptionConfig().language
+
+    text = transcriber.transcribe(np.zeros(16000, dtype=np.float32))
+
+    assert text == "こんにちは お願いします"

--- a/uv.lock
+++ b/uv.lock
@@ -412,7 +412,7 @@ wheels = [
 
 [[package]]
 name = "meeting-minutes"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },


### PR DESCRIPTION
## Summary
- Preserve Whisper segment timestamps and render each live transcript line per segment
- Keep `transcribe()` compatibility while adding `transcribe_segments()` for timestamp-aware output
- Add unit coverage for segment preservation and joined-text compatibility

## Testing
- Added unit tests for segment extraction and legacy text joining behavior
- Local validation passed with lint, type checking, and pytest