### PR TITLE
Refactor live flow and summary orchestration

### DIFF
--- a/src/meeting_minutes/cli.py
+++ b/src/meeting_minutes/cli.py
@@ -9,6 +9,7 @@ from meeting_minutes.checks import run_checks
 from meeting_minutes.config import apply_overrides, load_config
 from meeting_minutes.devices import list_input_devices
 from meeting_minutes.errors import MeetingMinutesError
+from meeting_minutes.summarize import MinutesMode
 
 app = typer.Typer(no_args_is_help=True)
 console = Console()
@@ -16,6 +17,28 @@ console = Console()
 
 def _disabled_when(flag: bool) -> bool | None:
     return False if flag else None
+
+
+def _generate_minutes_command(
+    transcript_file: Path,
+    mode: MinutesMode,
+    output: Path | None,
+    config: Path | None,
+) -> None:
+    from meeting_minutes.summarize import generate_minutes
+
+    app_config = load_config(config)
+    try:
+        output_path = generate_minutes(
+            transcript_file,
+            mode,
+            output,
+            app_config,
+        )
+    except MeetingMinutesError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    console.print(f"[green]Generated:[/green] {output_path}")
 
 
 @app.command()
@@ -112,20 +135,7 @@ def draft(
     config: Annotated[Path | None, typer.Option("--config", help="TOML設定ファイル")] = None,
 ) -> None:
     """現在までの文字起こしから議事録ドラフトを生成します。"""
-    from meeting_minutes.summarize import generate_minutes
-
-    app_config = load_config(config)
-    try:
-        output_path = generate_minutes(
-            transcript_file,
-            "draft",
-            output,
-            app_config,
-        )
-    except MeetingMinutesError as exc:
-        console.print(f"[red]{exc}[/red]")
-        raise typer.Exit(code=1) from exc
-    console.print(f"[green]Generated:[/green] {output_path}")
+    _generate_minutes_command(transcript_file, "draft", output, config)
 
 
 @app.command()
@@ -135,20 +145,7 @@ def finalize(
     config: Annotated[Path | None, typer.Option("--config", help="TOML設定ファイル")] = None,
 ) -> None:
     """文字起こし全体から最終議事録を生成します。"""
-    from meeting_minutes.summarize import generate_minutes
-
-    app_config = load_config(config)
-    try:
-        output_path = generate_minutes(
-            transcript_file,
-            "final",
-            output,
-            app_config,
-        )
-    except MeetingMinutesError as exc:
-        console.print(f"[red]{exc}[/red]")
-        raise typer.Exit(code=1) from exc
-    console.print(f"[green]Generated:[/green] {output_path}")
+    _generate_minutes_command(transcript_file, "final", output, config)
 
 
 if __name__ == "__main__":

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -1,8 +1,11 @@
 import logging
 import wave
+from dataclasses import dataclass
 from datetime import datetime
 from math import ceil, floor
+from pathlib import Path
 
+import numpy as np
 from rich.console import Console
 
 from meeting_minutes.audio_output import WavAudioWriter
@@ -44,13 +47,48 @@ def _close_audio_writer(audio_writer: WavAudioWriter, errors: list[str]) -> None
         errors.append(f"audio recording close failed: {exc}")
 
 
+@dataclass
+class AudioRecording:
+    path: Path | None
+    writer: WavAudioWriter | None = None
+
+    @classmethod
+    def open(cls, path: Path | None, *, sample_rate: int, errors: list[str]) -> "AudioRecording":
+        if path is None:
+            return cls(path=None)
+        try:
+            writer = WavAudioWriter(path, sample_rate=sample_rate)
+        except AUDIO_RECORDING_ERRORS as exc:
+            logger.exception("Audio recording disabled")
+            errors.append(f"audio recording disabled: {exc}")
+            return cls(path=None)
+        return cls(path=path, writer=writer)
+
+    def write(self, chunk: np.ndarray, errors: list[str]) -> None:
+        if self.writer is None:
+            return
+        try:
+            self.writer.write(chunk)
+        except AUDIO_RECORDING_ERRORS as exc:
+            logger.exception("Audio recording disabled")
+            errors.append(f"audio recording disabled: {exc}")
+            _close_audio_writer(self.writer, errors)
+            self.writer = None
+            self.path = None
+
+    def close(self, errors: list[str]) -> None:
+        if self.writer is not None:
+            _close_audio_writer(self.writer, errors)
+            self.writer = None
+
+
 def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
     started_at = datetime.now()
     input_device = resolve_input_device(config.audio.device, config.audio.device_index)
     session_dir = create_session_dir(config.output.base_dir, started_at)
     transcript_path = session_dir / "transcript_live.md" if config.output.save_transcript else None
     audio_path = session_dir / "audio_live.wav" if config.output.save_audio else None
-    audio_writer: WavAudioWriter | None = None
+    audio_recording = AudioRecording(path=audio_path)
     errors: list[str] = []
 
     if transcript_path is not None:
@@ -74,13 +112,11 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
     next_draft_at = interval_seconds if interval_seconds > 0 else None
 
     try:
-        if audio_path is not None:
-            try:
-                audio_writer = WavAudioWriter(audio_path, sample_rate=config.audio.sample_rate)
-            except AUDIO_RECORDING_ERRORS as exc:
-                logger.exception("Audio recording disabled")
-                errors.append(f"audio recording disabled: {exc}")
-                audio_path = None
+        audio_recording = AudioRecording.open(
+            audio_path,
+            sample_rate=config.audio.sample_rate,
+            errors=errors,
+        )
 
         for chunk in audio_chunks(
             device_index=input_device.index,
@@ -90,15 +126,7 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
         ):
             chunk_start_seconds = elapsed_seconds
             elapsed_seconds += config.audio.chunk_seconds
-            if audio_writer is not None:
-                try:
-                    audio_writer.write(chunk)
-                except AUDIO_RECORDING_ERRORS as exc:
-                    logger.exception("Audio recording disabled")
-                    errors.append(f"audio recording disabled: {exc}")
-                    _close_audio_writer(audio_writer, errors)
-                    audio_writer = None
-                    audio_path = None
+            audio_recording.write(chunk, errors)
             segments = transcriber.transcribe_segments(chunk)
             text = " ".join(segment.text for segment in segments).strip()
             if not dedupe.should_keep(text):
@@ -141,8 +169,7 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
         errors.append(str(exc))
         raise
     finally:
-        if audio_writer is not None:
-            _close_audio_writer(audio_writer, errors)
+        audio_recording.close(errors)
         ended_at = datetime.now()
         metadata = build_metadata(
             started_at=started_at,
@@ -150,7 +177,7 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
             input_device=input_device,
             config=config,
             transcript_path=transcript_path,
-            audio_path=audio_path,
+            audio_path=audio_recording.path,
             errors=errors,
         )
         write_metadata(session_dir / "metadata.json", metadata)

--- a/src/meeting_minutes/summarize.py
+++ b/src/meeting_minutes/summarize.py
@@ -49,6 +49,34 @@ Part: {part_number}/{total_parts}
 """
 
 
+def _generate_from_chunks(
+    client: OllamaClient,
+    mode: MinutesMode,
+    chunks: list[str],
+    vocabulary_section: str,
+) -> str:
+    if len(chunks) == 1:
+        return client.generate(_prompt_for(mode, chunks[0], vocabulary_section))
+
+    summaries = [
+        client.generate(_summary_prompt(index, len(chunks), chunk, vocabulary_section))
+        for index, chunk in enumerate(chunks, start=1)
+    ]
+    integrated_source = _format_chunk_summaries(summaries)
+    return client.generate(_prompt_for(mode, integrated_source, vocabulary_section))
+
+
+def _format_chunk_summaries(summaries: list[str]) -> str:
+    return "\n\n".join(
+        f"## Chunk Summary {index}\n{summary}" for index, summary in enumerate(summaries, start=1)
+    )
+
+
+def _default_output_path(transcript_file: Path, mode: MinutesMode) -> Path:
+    output_name = "minutes_draft.md" if mode == "draft" else "minutes.md"
+    return transcript_file.parent / output_name
+
+
 def generate_minutes(
     transcript_file: Path,
     mode: MinutesMode,
@@ -67,22 +95,10 @@ def generate_minutes(
     )
 
     with OllamaClient(config.summarization) as client:
-        if len(chunks) == 1:
-            minutes = client.generate(_prompt_for(mode, transcript, vocabulary_section))
-        else:
-            summaries = [
-                client.generate(_summary_prompt(index, len(chunks), chunk, vocabulary_section))
-                for index, chunk in enumerate(chunks, start=1)
-            ]
-            integrated_source = "\n\n".join(
-                f"## Chunk Summary {index}\n{summary}"
-                for index, summary in enumerate(summaries, start=1)
-            )
-            minutes = client.generate(_prompt_for(mode, integrated_source, vocabulary_section))
+        minutes = _generate_from_chunks(client, mode, chunks, vocabulary_section)
 
     if output is None:
-        output_name = "minutes_draft.md" if mode == "draft" else "minutes.md"
-        output = transcript_file.parent / output_name
+        output = _default_output_path(transcript_file, mode)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(minutes.rstrip() + "\n", encoding="utf-8")
     return output

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -10,6 +10,54 @@ from meeting_minutes.live import _segment_elapsed_range, run_live
 from meeting_minutes.transcribe import TranscriptionSegment
 
 
+@pytest.fixture
+def input_device() -> InputDevice:
+    return InputDevice(
+        index=1,
+        name="Mic",
+        channels=1,
+        default_sample_rate=16000,
+        is_blackhole=False,
+    )
+
+
+@pytest.fixture
+def single_chunk_audio(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
+        yield np.zeros(16000, dtype=np.float32)
+
+    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
+
+
+@pytest.fixture
+def fake_transcriber(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeTranscriber:
+        def __init__(self, _config: object, *, initial_prompt: object = None) -> None:
+            pass
+
+        def transcribe_segments(self, _chunk: np.ndarray) -> list[TranscriptionSegment]:
+            return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
+
+    monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
+
+
+@pytest.fixture
+def live_dependencies(
+    input_device: InputDevice,
+    single_chunk_audio: None,
+    fake_transcriber: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
+
+
+def live_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        audio=AudioConfig(chunk_seconds=1),
+        output=OutputConfig(base_dir=tmp_path),
+    )
+
+
 def test_segment_elapsed_range_encloses_segment_times() -> None:
     segment = TranscriptionSegment(start=0.51, end=1.49, text="hello")
 
@@ -18,36 +66,9 @@ def test_segment_elapsed_range_encloses_segment_times() -> None:
 
 def test_run_live_writes_audio_and_transcript(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    live_dependencies: None,
 ) -> None:
-    input_device = InputDevice(
-        index=1,
-        name="Mic",
-        channels=1,
-        default_sample_rate=16000,
-        is_blackhole=False,
-    )
-
-    def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
-        yield np.zeros(16000, dtype=np.float32)
-
-    class FakeTranscriber:
-        def __init__(self, _config: object, *, initial_prompt: object = None) -> None:
-            pass
-
-        def transcribe_segments(self, _chunk: np.ndarray) -> list[TranscriptionSegment]:
-            return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
-
-    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
-    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
-    monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
-
-    run_live(
-        AppConfig(
-            audio=AudioConfig(chunk_seconds=1),
-            output=OutputConfig(base_dir=tmp_path),
-        )
-    )
+    run_live(live_config(tmp_path))
 
     transcript = next(tmp_path.glob("*/transcript_live.md")).read_text(encoding="utf-8")
     audio_path = next(tmp_path.glob("*/audio_live.wav"))
@@ -57,41 +78,16 @@ def test_run_live_writes_audio_and_transcript(
 
 def test_run_live_continues_when_audio_writer_cannot_open(
     tmp_path: Path,
+    live_dependencies: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    input_device = InputDevice(
-        index=1,
-        name="Mic",
-        channels=1,
-        default_sample_rate=16000,
-        is_blackhole=False,
-    )
-
-    def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
-        yield np.zeros(16000, dtype=np.float32)
-
-    class FakeTranscriber:
-        def __init__(self, _config: object, *, initial_prompt: object = None) -> None:
-            pass
-
-        def transcribe_segments(self, _chunk: np.ndarray) -> list[TranscriptionSegment]:
-            return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
-
     class BrokenAudioWriter:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             raise OSError("disk full")
 
-    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
-    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
-    monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
     monkeypatch.setattr("meeting_minutes.live.WavAudioWriter", BrokenAudioWriter)
 
-    run_live(
-        AppConfig(
-            audio=AudioConfig(chunk_seconds=1),
-            output=OutputConfig(base_dir=tmp_path),
-        )
-    )
+    run_live(live_config(tmp_path))
 
     session_dir = next(tmp_path.glob("*_live_meeting"))
     transcript = (session_dir / "transcript_live.md").read_text(encoding="utf-8")
@@ -102,26 +98,9 @@ def test_run_live_continues_when_audio_writer_cannot_open(
 
 def test_run_live_continues_when_audio_writer_write_fails(
     tmp_path: Path,
+    live_dependencies: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    input_device = InputDevice(
-        index=1,
-        name="Mic",
-        channels=1,
-        default_sample_rate=16000,
-        is_blackhole=False,
-    )
-
-    def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
-        yield np.zeros(16000, dtype=np.float32)
-
-    class FakeTranscriber:
-        def __init__(self, _config: object, *, initial_prompt: object = None) -> None:
-            pass
-
-        def transcribe_segments(self, _chunk: np.ndarray) -> list[TranscriptionSegment]:
-            return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
-
     class BrokenAudioWriter:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass
@@ -132,17 +111,9 @@ def test_run_live_continues_when_audio_writer_write_fails(
         def close(self) -> None:
             pass
 
-    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
-    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
-    monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
     monkeypatch.setattr("meeting_minutes.live.WavAudioWriter", BrokenAudioWriter)
 
-    run_live(
-        AppConfig(
-            audio=AudioConfig(chunk_seconds=1),
-            output=OutputConfig(base_dir=tmp_path),
-        )
-    )
+    run_live(live_config(tmp_path))
 
     session_dir = next(tmp_path.glob("*_live_meeting"))
     transcript = (session_dir / "transcript_live.md").read_text(encoding="utf-8")
@@ -153,26 +124,9 @@ def test_run_live_continues_when_audio_writer_write_fails(
 
 def test_run_live_writes_metadata_when_audio_writer_close_fails(
     tmp_path: Path,
+    live_dependencies: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    input_device = InputDevice(
-        index=1,
-        name="Mic",
-        channels=1,
-        default_sample_rate=16000,
-        is_blackhole=False,
-    )
-
-    def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
-        yield np.zeros(16000, dtype=np.float32)
-
-    class FakeTranscriber:
-        def __init__(self, _config: object, *, initial_prompt: object = None) -> None:
-            pass
-
-        def transcribe_segments(self, _chunk: np.ndarray) -> list[TranscriptionSegment]:
-            return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
-
     class BrokenAudioWriter:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             pass
@@ -183,17 +137,9 @@ def test_run_live_writes_metadata_when_audio_writer_close_fails(
         def close(self) -> None:
             raise OSError("flush failed")
 
-    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
-    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
-    monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
     monkeypatch.setattr("meeting_minutes.live.WavAudioWriter", BrokenAudioWriter)
 
-    run_live(
-        AppConfig(
-            audio=AudioConfig(chunk_seconds=1),
-            output=OutputConfig(base_dir=tmp_path),
-        )
-    )
+    run_live(live_config(tmp_path))
 
     session_dir = next(tmp_path.glob("*_live_meeting"))
     metadata = (session_dir / "metadata.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Deduplicate the `draft` and `finalize` CLI commands behind a shared helper
- Encapsulate live audio writer state in `AudioRecording` to simplify error handling
- Split minutes generation into smaller helpers for chunk orchestration and output path selection
- Reduce repeated setup in live tests with shared fixtures

## Testing
- Added and consolidated unit coverage around live session behavior and the refactored summary flow
- `ruff format`, `ruff check`, `mypy`, and `pytest` passed locally