### PR TITLE
[codex] Handle split transcripts and audio overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ uv run meeting-minutes devices
 uv run meeting-minutes live --device "BlackHole 2ch"
 uv run meeting-minutes draft ./output/current/transcript_live.md
 uv run meeting-minutes finalize ./output/current/transcript_live.md
+# liveを再起動して transcript が分かれた場合
+uv run meeting-minutes finalize ./output/session-1/transcript_live.md ./output/session-2/transcript_live.md
 ```
 
 設定例は [config.example.toml](./config.example.toml) を参照してください。
@@ -35,4 +37,5 @@ uv run meeting-minutes finalize ./output/current/transcript_live.md
 - 議事録生成はローカルOllama API (`http://localhost:11434`) を使います。
 - `live` はデフォルトでセッションディレクトリに `audio_live.wav` を保存します。保存は `--no-save-audio` または `output.save_audio=false` で無効化できます。
 - `live` はCtrl+Cで停止し、`metadata.json` を保存します。
+- 音声取り逃がし時は既定で停止します。少量の欠落を許容して続行する場合は `--continue-on-overflow` または `audio.abort_on_overflow=false` を使います。
 - 用語集と参加者名のテキストファイルを `[vocabulary]` セクションで指定すると、固有名詞の誤認識と表記揺れを抑制できます。詳しくは [docs/cli.md](./docs/cli.md#語彙ヒントvocabulary) を参照してください。

--- a/config.example.toml
+++ b/config.example.toml
@@ -4,6 +4,8 @@ device = "BlackHole 2ch"
 sample_rate = 16000
 channels = 1
 chunk_seconds = 8
+# true: 音声取り逃がし時に停止する。false: metadataに記録して続行する。
+abort_on_overflow = true
 
 [transcription]
 whisper_model = "small"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,8 @@ uv run meeting-minutes live --device-index 1
 | `--config` | なし | TOML設定ファイル |
 | `--no-save` | `false` | transcriptを保存しない |
 | `--no-save-audio` | `false` | 録音WAVを保存しない |
+| `--continue-on-overflow` | `false` | 音声取り逃がし時も `metadata.json` に記録して続行 |
+| `--abort-on-overflow` | 設定ファイルまたは `true` | 音声取り逃がし時に停止 |
 | `--draft-interval-minutes` | `0` | 指定分ごとにドラフト生成。`0`なら無効 |
 
 出力先の例:
@@ -117,6 +119,8 @@ output/
 `transcript_live.md` の本文は、後から音声と照合しやすいように `[開始 - 終了] text` 形式で保存されます。
 
 停止するには `Ctrl+C` を押します。停止時に `metadata.json` が保存されます。
+
+音声入力の処理が追いつかず一部ブロックを取り逃がした場合、既定では停止します。長時間会議で少量の欠落を許容して継続したい場合は `--continue-on-overflow` または設定ファイルの `audio.abort_on_overflow = false` を使います。継続時も取り逃がしは `metadata.json` の `errors` に記録されます。
 
 ### BlackHole 64chを使う場合
 
@@ -140,10 +144,18 @@ uv run meeting-minutes live --device "BlackHole 64ch" --channels 2
 uv run meeting-minutes draft ./output/2026-04-28_193822_live_meeting/transcript_live.md
 ```
 
+途中で `live` を再起動した場合など、複数の transcript を順番に指定できます。
+
+```bash
+uv run meeting-minutes draft \
+  ./output/session-1/transcript_live.md \
+  ./output/session-2/transcript_live.md
+```
+
 既定の出力先:
 
 ```text
-minutes_draft.md
+先頭 transcript と同じディレクトリの minutes_draft.md
 ```
 
 出力先を指定する場合:
@@ -166,10 +178,18 @@ uv run meeting-minutes draft ./output/current/transcript_live.md --config ./conf
 uv run meeting-minutes finalize ./output/2026-04-28_193822_live_meeting/transcript_live.md
 ```
 
+途中で `live` を再起動した場合など、複数の transcript を順番に指定できます。
+
+```bash
+uv run meeting-minutes finalize \
+  ./output/session-1/transcript_live.md \
+  ./output/session-2/transcript_live.md
+```
+
 既定の出力先:
 
 ```text
-minutes.md
+先頭 transcript と同じディレクトリの minutes.md
 ```
 
 出力先を指定する場合:
@@ -195,6 +215,8 @@ device = "BlackHole 64ch"
 sample_rate = 16000
 channels = 1
 chunk_seconds = 8
+# true: 音声取り逃がし時に停止する。false: metadataに記録して続行する。
+abort_on_overflow = true
 
 [transcription]
 whisper_model = "small"

--- a/src/meeting_minutes/audio_stream.py
+++ b/src/meeting_minutes/audio_stream.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from queue import Full, Queue
 
 import numpy as np
@@ -17,6 +17,8 @@ def audio_chunks(
     sample_rate: int,
     channels: int,
     chunk_seconds: int,
+    abort_on_overflow: bool = True,
+    on_overflow: Callable[[str], None] | None = None,
 ) -> Iterator[np.ndarray]:
     frames_per_chunk = sample_rate * chunk_seconds
     block_frames = max(sample_rate // 2, 1)
@@ -51,9 +53,11 @@ def audio_chunks(
             if dropped_blocks:
                 dropped = dropped_blocks
                 dropped_blocks = 0
-                raise AudioOverflowError(
-                    f"音声入力の処理が追いつかず、{dropped} block(s) を取り逃がしました。"
-                )
+                message = f"音声入力の処理が追いつかず、{dropped} block(s) を取り逃がしました。"
+                if abort_on_overflow:
+                    raise AudioOverflowError(message)
+                if on_overflow is not None:
+                    on_overflow(message)
             while pending.shape[0] < frames_per_chunk:
                 pending = np.concatenate((pending, queue.get()))
             chunk = pending[:frames_per_chunk]

--- a/src/meeting_minutes/audio_stream.py
+++ b/src/meeting_minutes/audio_stream.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Iterator
 from queue import Full, Queue
+from threading import Lock
 
 import numpy as np
 import sounddevice as sd
@@ -18,12 +19,25 @@ def audio_chunks(
     channels: int,
     chunk_seconds: int,
     abort_on_overflow: bool = True,
-    on_overflow: Callable[[str], None] | None = None,
+    on_overflow: Callable[[int], None] | None = None,
 ) -> Iterator[np.ndarray]:
     frames_per_chunk = sample_rate * chunk_seconds
     block_frames = max(sample_rate // 2, 1)
     queue: Queue[np.ndarray] = Queue(maxsize=240)  # 120 seconds at the current ~0.5s block size.
     dropped_blocks = 0
+    dropped_blocks_lock = Lock()
+
+    def add_dropped_block() -> None:
+        nonlocal dropped_blocks
+        with dropped_blocks_lock:
+            dropped_blocks += 1
+
+    def pop_dropped_blocks() -> int:
+        nonlocal dropped_blocks
+        with dropped_blocks_lock:
+            dropped = dropped_blocks
+            dropped_blocks = 0
+        return dropped
 
     def callback(
         indata: np.ndarray,
@@ -31,14 +45,13 @@ def audio_chunks(
         _time: object,
         status: sd.CallbackFlags,
     ) -> None:
-        nonlocal dropped_blocks
         if status.input_overflow:
-            dropped_blocks += 1
+            add_dropped_block()
         mono = indata.mean(axis=1) if indata.ndim > 1 else indata
         try:
             queue.put_nowait(np.asarray(mono, dtype=np.float32).copy())
         except Full:
-            dropped_blocks += 1
+            add_dropped_block()
 
     with sd.InputStream(
         samplerate=sample_rate,
@@ -50,14 +63,13 @@ def audio_chunks(
     ):
         pending = np.empty(0, dtype=np.float32)
         while True:
-            if dropped_blocks:
-                dropped = dropped_blocks
-                dropped_blocks = 0
+            dropped = pop_dropped_blocks()
+            if dropped:
                 message = f"音声入力の処理が追いつかず、{dropped} block(s) を取り逃がしました。"
                 if abort_on_overflow:
                     raise AudioOverflowError(message)
                 if on_overflow is not None:
-                    on_overflow(message)
+                    on_overflow(dropped)
             while pending.shape[0] < frames_per_chunk:
                 pending = np.concatenate((pending, queue.get()))
             chunk = pending[:frames_per_chunk]

--- a/src/meeting_minutes/cli.py
+++ b/src/meeting_minutes/cli.py
@@ -19,8 +19,20 @@ def _disabled_when(flag: bool) -> bool | None:
     return False if flag else None
 
 
+def _overflow_abort_setting(continue_on_overflow: bool, abort_on_overflow: bool) -> bool | None:
+    if continue_on_overflow and abort_on_overflow:
+        raise typer.BadParameter(
+            "--continue-on-overflow と --abort-on-overflow は同時に指定できません"
+        )
+    if continue_on_overflow:
+        return False
+    if abort_on_overflow:
+        return True
+    return None
+
+
 def _generate_minutes_command(
-    transcript_file: Path,
+    transcript_files: list[Path],
     mode: MinutesMode,
     output: Path | None,
     config: Path | None,
@@ -30,7 +42,7 @@ def _generate_minutes_command(
     app_config = load_config(config)
     try:
         output_path = generate_minutes(
-            transcript_file,
+            transcript_files,
             mode,
             output,
             app_config,
@@ -98,6 +110,14 @@ def live(
     config: Annotated[Path | None, typer.Option("--config", help="TOML設定ファイル")] = None,
     no_save: Annotated[bool, typer.Option("--no-save")] = False,
     no_save_audio: Annotated[bool, typer.Option("--no-save-audio")] = False,
+    continue_on_overflow: Annotated[
+        bool,
+        typer.Option("--continue-on-overflow", help="音声取り逃がし時も記録して続行する"),
+    ] = False,
+    abort_on_overflow: Annotated[
+        bool,
+        typer.Option("--abort-on-overflow", help="音声取り逃がし時に停止する"),
+    ] = False,
     draft_interval_minutes: Annotated[
         int, typer.Option("--draft-interval-minutes", help="0なら自動ドラフト生成なし")
     ] = 0,
@@ -119,6 +139,10 @@ def live(
             "summarization.ollama_model": ollama_model,
             "output.save_transcript": _disabled_when(no_save),
             "output.save_audio": _disabled_when(no_save_audio),
+            "audio.abort_on_overflow": _overflow_abort_setting(
+                continue_on_overflow,
+                abort_on_overflow,
+            ),
         },
     )
     try:
@@ -130,22 +154,22 @@ def live(
 
 @app.command()
 def draft(
-    transcript_file: Annotated[Path, typer.Argument(exists=True, readable=True)],
+    transcript_files: Annotated[list[Path], typer.Argument(exists=True, readable=True)],
     output: Annotated[Path | None, typer.Option("--output", "-o")] = None,
     config: Annotated[Path | None, typer.Option("--config", help="TOML設定ファイル")] = None,
 ) -> None:
     """現在までの文字起こしから議事録ドラフトを生成します。"""
-    _generate_minutes_command(transcript_file, "draft", output, config)
+    _generate_minutes_command(transcript_files, "draft", output, config)
 
 
 @app.command()
 def finalize(
-    transcript_file: Annotated[Path, typer.Argument(exists=True, readable=True)],
+    transcript_files: Annotated[list[Path], typer.Argument(exists=True, readable=True)],
     output: Annotated[Path | None, typer.Option("--output", "-o")] = None,
     config: Annotated[Path | None, typer.Option("--config", help="TOML設定ファイル")] = None,
 ) -> None:
     """文字起こし全体から最終議事録を生成します。"""
-    _generate_minutes_command(transcript_file, "final", output, config)
+    _generate_minutes_command(transcript_files, "final", output, config)
 
 
 if __name__ == "__main__":

--- a/src/meeting_minutes/config.py
+++ b/src/meeting_minutes/config.py
@@ -10,6 +10,7 @@ class AudioConfig(BaseModel):
     sample_rate: int = 16_000
     channels: int = 1
     chunk_seconds: int = Field(default=8, ge=1)
+    abort_on_overflow: bool = True
 
 
 class TranscriptionConfig(BaseModel):

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -110,11 +110,27 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
     elapsed_seconds = 0
     interval_seconds = draft_interval_minutes * 60
     next_draft_at = interval_seconds if interval_seconds > 0 else None
+    overflow_events = 0
+    overflow_blocks = 0
+    overflow_error_index: int | None = None
 
-    def record_audio_overflow(message: str) -> None:
-        logger.warning(message)
-        errors.append(message)
-        console.print(f"[yellow]{message} 続行します。[/yellow]")
+    def record_audio_overflow(dropped_blocks: int) -> None:
+        nonlocal overflow_blocks, overflow_error_index, overflow_events
+        overflow_events += 1
+        overflow_blocks += dropped_blocks
+        message = (
+            "音声入力の処理が追いつかず、"
+            f"合計 {overflow_blocks} block(s) を {overflow_events} event(s) で取り逃がしました。"
+        )
+        if overflow_error_index is None:
+            overflow_error_index = len(errors)
+            errors.append(message)
+        else:
+            errors[overflow_error_index] = message
+
+        if overflow_events == 1 or overflow_events % 10 == 0:
+            logger.warning(message)
+            console.print(f"[yellow]{message} 続行します。[/yellow]")
 
     try:
         audio_recording = AudioRecording.open(

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -111,6 +111,11 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
     interval_seconds = draft_interval_minutes * 60
     next_draft_at = interval_seconds if interval_seconds > 0 else None
 
+    def record_audio_overflow(message: str) -> None:
+        logger.warning(message)
+        errors.append(message)
+        console.print(f"[yellow]{message} 続行します。[/yellow]")
+
     try:
         audio_recording = AudioRecording.open(
             audio_path,
@@ -123,6 +128,8 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
             sample_rate=config.audio.sample_rate,
             channels=config.audio.channels,
             chunk_seconds=config.audio.chunk_seconds,
+            abort_on_overflow=config.audio.abort_on_overflow,
+            on_overflow=record_audio_overflow,
         ):
             chunk_start_seconds = elapsed_seconds
             elapsed_seconds += config.audio.chunk_seconds

--- a/src/meeting_minutes/summarize.py
+++ b/src/meeting_minutes/summarize.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Literal
 
 from meeting_minutes.config import AppConfig
+from meeting_minutes.errors import MeetingMinutesError
 from meeting_minutes.ollama_client import OllamaClient
 from meeting_minutes.prompts import DRAFT_PROMPT, FINAL_PROMPT
 from meeting_minutes.vocabulary import build_summary_section, load_vocabulary
@@ -82,7 +83,7 @@ def _read_transcripts(transcript_files: Sequence[Path]) -> str:
     sections = []
     for index, transcript_file in enumerate(transcript_files, start=1):
         transcript = transcript_file.read_text(encoding="utf-8").strip()
-        sections.append(f"## Transcript {index}: {transcript_file}\n\n{transcript}")
+        sections.append(f"## Transcript {index}: {transcript_file.name}\n\n{transcript}")
     return "\n\n".join(sections)
 
 
@@ -96,7 +97,7 @@ def generate_minutes(
         [transcript_file] if isinstance(transcript_file, Path) else list(transcript_file)
     )
     if not transcript_files:
-        raise ValueError("At least one transcript file is required.")
+        raise MeetingMinutesError("文字起こしファイルを1つ以上指定してください。")
 
     transcript = _read_transcripts(transcript_files)
     chunks = split_text(

--- a/src/meeting_minutes/summarize.py
+++ b/src/meeting_minutes/summarize.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Literal
 
@@ -77,13 +78,27 @@ def _default_output_path(transcript_file: Path, mode: MinutesMode) -> Path:
     return transcript_file.parent / output_name
 
 
+def _read_transcripts(transcript_files: Sequence[Path]) -> str:
+    sections = []
+    for index, transcript_file in enumerate(transcript_files, start=1):
+        transcript = transcript_file.read_text(encoding="utf-8").strip()
+        sections.append(f"## Transcript {index}: {transcript_file}\n\n{transcript}")
+    return "\n\n".join(sections)
+
+
 def generate_minutes(
-    transcript_file: Path,
+    transcript_file: Path | Sequence[Path],
     mode: MinutesMode,
     output: Path | None,
     config: AppConfig,
 ) -> Path:
-    transcript = transcript_file.read_text(encoding="utf-8")
+    transcript_files = (
+        [transcript_file] if isinstance(transcript_file, Path) else list(transcript_file)
+    )
+    if not transcript_files:
+        raise ValueError("At least one transcript file is required.")
+
+    transcript = _read_transcripts(transcript_files)
     chunks = split_text(
         transcript,
         chunk_size=config.chunking.chunk_size,
@@ -98,7 +113,7 @@ def generate_minutes(
         minutes = _generate_from_chunks(client, mode, chunks, vocabulary_section)
 
     if output is None:
-        output = _default_output_path(transcript_file, mode)
+        output = _default_output_path(transcript_files[0], mode)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(minutes.rstrip() + "\n", encoding="utf-8")
     return output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ def test_load_config_from_toml(tmp_path: Path) -> None:
 [audio]
 device = "BlackHole 2ch"
 chunk_seconds = 5
+abort_on_overflow = false
 
 [summarization]
 ollama_model = "gemma4:latest"
@@ -23,6 +24,7 @@ ollama_model = "gemma4:latest"
 
     assert config.audio.device == "BlackHole 2ch"
     assert config.audio.chunk_seconds == 5
+    assert not config.audio.abort_on_overflow
     assert config.summarization.ollama_model == "gemma4:latest"
 
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -161,7 +162,8 @@ def test_run_live_continues_and_records_audio_overflow_when_configured(
     ) -> Iterator[np.ndarray]:
         assert not abort_on_overflow
         assert callable(on_overflow)
-        on_overflow("音声入力の処理が追いつかず、1 block(s) を取り逃がしました。")
+        on_overflow(1)
+        on_overflow(2)
         yield np.zeros(16000, dtype=np.float32)
 
     monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
@@ -175,9 +177,11 @@ def test_run_live_continues_and_records_audio_overflow_when_configured(
 
     session_dir = next(tmp_path.glob("*_live_meeting"))
     transcript = (session_dir / "transcript_live.md").read_text(encoding="utf-8")
-    metadata = (session_dir / "metadata.json").read_text(encoding="utf-8")
+    metadata = json.loads((session_dir / "metadata.json").read_text(encoding="utf-8"))
     assert "[00:00:00 - 00:00:01] hello" in transcript
-    assert "1 block(s) を取り逃がしました" in metadata
+    assert metadata["errors"] == [
+        "音声入力の処理が追いつかず、合計 3 block(s) を 2 event(s) で取り逃がしました。"
+    ]
 
 
 def test_run_live_aborts_on_audio_overflow_by_default(

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from meeting_minutes.audio_stream import AudioOverflowError
 from meeting_minutes.config import AppConfig, AudioConfig, OutputConfig
 from meeting_minutes.devices import InputDevice
 from meeting_minutes.live import _segment_elapsed_range, run_live
@@ -144,3 +145,57 @@ def test_run_live_writes_metadata_when_audio_writer_close_fails(
     session_dir = next(tmp_path.glob("*_live_meeting"))
     metadata = (session_dir / "metadata.json").read_text(encoding="utf-8")
     assert "audio recording close failed: flush failed" in metadata
+
+
+def test_run_live_continues_and_records_audio_overflow_when_configured(
+    tmp_path: Path,
+    input_device: InputDevice,
+    fake_transcriber: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_audio_chunks(
+        *,
+        abort_on_overflow: bool,
+        on_overflow: object,
+        **_kwargs: object,
+    ) -> Iterator[np.ndarray]:
+        assert not abort_on_overflow
+        assert callable(on_overflow)
+        on_overflow("音声入力の処理が追いつかず、1 block(s) を取り逃がしました。")
+        yield np.zeros(16000, dtype=np.float32)
+
+    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
+    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
+
+    config = AppConfig(
+        audio=AudioConfig(chunk_seconds=1, abort_on_overflow=False),
+        output=OutputConfig(base_dir=tmp_path),
+    )
+    run_live(config)
+
+    session_dir = next(tmp_path.glob("*_live_meeting"))
+    transcript = (session_dir / "transcript_live.md").read_text(encoding="utf-8")
+    metadata = (session_dir / "metadata.json").read_text(encoding="utf-8")
+    assert "[00:00:00 - 00:00:01] hello" in transcript
+    assert "1 block(s) を取り逃がしました" in metadata
+
+
+def test_run_live_aborts_on_audio_overflow_by_default(
+    tmp_path: Path,
+    input_device: InputDevice,
+    fake_transcriber: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_audio_chunks(*, abort_on_overflow: bool, **_kwargs: object) -> Iterator[np.ndarray]:
+        assert abort_on_overflow
+        raise AudioOverflowError("音声入力の処理が追いつかず、1 block(s) を取り逃がしました。")
+
+    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
+    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
+
+    with pytest.raises(AudioOverflowError):
+        run_live(live_config(tmp_path))
+
+    session_dir = next(tmp_path.glob("*_live_meeting"))
+    metadata = (session_dir / "metadata.json").read_text(encoding="utf-8")
+    assert "1 block(s) を取り逃がしました" in metadata

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,7 +1,57 @@
-from meeting_minutes.summarize import split_text
+from pathlib import Path
+from types import TracebackType
+
+import pytest
+
+from meeting_minutes.config import AppConfig
+from meeting_minutes.summarize import generate_minutes, split_text
 
 
 def test_split_text_uses_overlap() -> None:
     chunks = split_text("abcdefghij", chunk_size=4, chunk_overlap=1)
 
     assert chunks == ["abcd", "defg", "ghij"]
+
+
+def test_generate_minutes_combines_multiple_transcripts_in_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = tmp_path / "session-1" / "transcript_live.md"
+    second = tmp_path / "session-2" / "transcript_live.md"
+    first.parent.mkdir()
+    second.parent.mkdir()
+    first.write_text("[00:00:01] first transcript\n", encoding="utf-8")
+    second.write_text("[00:20:00] second transcript\n", encoding="utf-8")
+    prompts: list[str] = []
+
+    class FakeOllamaClient:
+        def __init__(self, _config: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeOllamaClient":
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: TracebackType | None,
+        ) -> None:
+            pass
+
+        def generate(self, prompt: str) -> str:
+            prompts.append(prompt)
+            return "generated minutes"
+
+    monkeypatch.setattr("meeting_minutes.summarize.OllamaClient", FakeOllamaClient)
+
+    output = generate_minutes([first, second], "final", None, AppConfig())
+
+    assert output == first.parent / "minutes.md"
+    assert output.read_text(encoding="utf-8") == "generated minutes\n"
+    assert "## Transcript 1:" in prompts[0]
+    assert "first transcript" in prompts[0]
+    assert "## Transcript 2:" in prompts[0]
+    assert "second transcript" in prompts[0]
+    assert prompts[0].index("first transcript") < prompts[0].index("second transcript")

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -4,6 +4,7 @@ from types import TracebackType
 import pytest
 
 from meeting_minutes.config import AppConfig
+from meeting_minutes.errors import MeetingMinutesError
 from meeting_minutes.summarize import generate_minutes, split_text
 
 
@@ -50,8 +51,15 @@ def test_generate_minutes_combines_multiple_transcripts_in_order(
 
     assert output == first.parent / "minutes.md"
     assert output.read_text(encoding="utf-8") == "generated minutes\n"
-    assert "## Transcript 1:" in prompts[0]
+    assert "## Transcript 1: transcript_live.md" in prompts[0]
+    assert str(first.parent) not in prompts[0]
     assert "first transcript" in prompts[0]
-    assert "## Transcript 2:" in prompts[0]
+    assert "## Transcript 2: transcript_live.md" in prompts[0]
+    assert str(second.parent) not in prompts[0]
     assert "second transcript" in prompts[0]
     assert prompts[0].index("first transcript") < prompts[0].index("second transcript")
+
+
+def test_generate_minutes_raises_domain_error_for_empty_transcripts() -> None:
+    with pytest.raises(MeetingMinutesError, match="文字起こしファイルを1つ以上指定してください"):
+        generate_minutes([], "final", None, AppConfig())


### PR DESCRIPTION
## Summary

- Allow draft and finalize to accept multiple transcript files and combine them in the provided order.
- Add configurable audio overflow behavior with audio.abort_on_overflow, --continue-on-overflow, and --abort-on-overflow.
- Record continued audio overflow events in session metadata and update README/CLI docs.

## Why

A long live session can be interrupted by audio input overflow, leaving the meeting transcript split across multiple session directories. This change makes post-processing those split transcripts straightforward and lets users choose whether a small overflow should stop the live session or be recorded while continuing.

## Validation

- uv run ruff check src tests
- uv run mypy src
- uv run pytest
- uv run meeting-minutes live --help
- uv run meeting-minutes finalize --help
- CodeRabbit review: addressed the unreachable test yield; kept the Japanese overflow continuation message for consistency with the CLI's Japanese user-facing text.