### PR TITLE
Add VAD-based speech segmentation to live transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ uv run meeting-minutes finalize ./output/session-1/transcript_live.md ./output/s
 - 音声と文字起こし内容はクラウドAPIへ送信しません。
 - 議事録生成はローカルOllama API (`http://localhost:11434`) を使います。
 - `live` はデフォルトでセッションディレクトリに `audio_live.wav` を保存します。保存は `--no-save-audio` または `output.save_audio=false` で無効化できます。
+- `live` はデフォルトでVADを使い、発話単位で文字起こしします。固定秒数チャンクに戻す場合は `--no-vad` または `vad.enabled=false` を使います。
 - `live` はCtrl+Cで停止し、`metadata.json` を保存します。
 - 音声取り逃がし時は既定で停止します。少量の欠落を許容して続行する場合は `--continue-on-overflow` または `audio.abort_on_overflow=false` を使います。
 - 用語集と参加者名のテキストファイルを `[vocabulary]` セクションで指定すると、固有名詞の誤認識と表記揺れを抑制できます。詳しくは [docs/cli.md](./docs/cli.md#語彙ヒントvocabulary) を参照してください。

--- a/config.example.toml
+++ b/config.example.toml
@@ -7,6 +7,15 @@ chunk_seconds = 8
 # true: 音声取り逃がし時に停止する。false: metadataに記録して続行する。
 abort_on_overflow = true
 
+[vad]
+enabled = true
+frame_ms = 30
+speech_threshold = 0.01
+silence_seconds = 0.8
+min_speech_seconds = 0.3
+max_speech_seconds = 15.0
+padding_seconds = 0.2
+
 [transcription]
 whisper_model = "small"
 language = "ja"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,7 @@ uv run meeting-minutes devices
 
 ## live
 
-指定した入力デバイスから音声を取得し、数秒ごとに文字起こしします。
+指定した入力デバイスから音声を取得し、VADで検出した発話単位で文字起こしします。
 
 ```bash
 uv run meeting-minutes live --device "BlackHole 64ch"
@@ -93,7 +93,7 @@ uv run meeting-minutes live --device-index 1
 | `--device-index` | 設定ファイルまたは既定入力 | 入力デバイスindex |
 | `--sample-rate` | `16000` | サンプルレート |
 | `--channels` | `1` | 入力チャンネル数 |
-| `--chunk-seconds` | `8` | 文字起こし1単位の秒数 |
+| `--chunk-seconds` | `8` | 音声取得チャンクの秒数 |
 | `--language` | `ja` | Whisperに渡す言語 |
 | `--whisper-model` | `small` | faster-whisperのモデル名 |
 | `--output-dir` | `output` | セッション出力先 |
@@ -101,6 +101,7 @@ uv run meeting-minutes live --device-index 1
 | `--config` | なし | TOML設定ファイル |
 | `--no-save` | `false` | transcriptを保存しない |
 | `--no-save-audio` | `false` | 録音WAVを保存しない |
+| `--no-vad` | `false` | VADによる発話単位分割を無効化し、固定秒数チャンクで文字起こし |
 | `--continue-on-overflow` | `false` | 音声取り逃がし時も `metadata.json` に記録して続行 |
 | `--abort-on-overflow` | 設定ファイルまたは `true` | 音声取り逃がし時に停止 |
 | `--draft-interval-minutes` | `0` | 指定分ごとにドラフト生成。`0`なら無効 |
@@ -119,6 +120,8 @@ output/
 `transcript_live.md` の本文は、後から音声と照合しやすいように `[開始 - 終了] text` 形式で保存されます。
 
 停止するには `Ctrl+C` を押します。停止時に `metadata.json` が保存されます。
+
+VADは既定で有効です。無音が続いたところで発話終了とみなし、短すぎる音声はノイズとして捨てます。長すぎる発話は `vad.max_speech_seconds` で強制分割します。固定秒数チャンクの従来動作に戻したい場合は `--no-vad` または設定ファイルの `vad.enabled = false` を使います。
 
 音声入力の処理が追いつかず一部ブロックを取り逃がした場合、既定では停止します。長時間会議で少量の欠落を許容して継続したい場合は `--continue-on-overflow` または設定ファイルの `audio.abort_on_overflow = false` を使います。継続時も取り逃がしは `metadata.json` の `errors` に記録されます。
 
@@ -217,6 +220,15 @@ channels = 1
 chunk_seconds = 8
 # true: 音声取り逃がし時に停止する。false: metadataに記録して続行する。
 abort_on_overflow = true
+
+[vad]
+enabled = true
+frame_ms = 30
+speech_threshold = 0.01
+silence_seconds = 0.8
+min_speech_seconds = 0.3
+max_speech_seconds = 15.0
+padding_seconds = 0.2
 
 [transcription]
 whisper_model = "small"

--- a/src/meeting_minutes/cli.py
+++ b/src/meeting_minutes/cli.py
@@ -110,6 +110,7 @@ def live(
     config: Annotated[Path | None, typer.Option("--config", help="TOML設定ファイル")] = None,
     no_save: Annotated[bool, typer.Option("--no-save")] = False,
     no_save_audio: Annotated[bool, typer.Option("--no-save-audio")] = False,
+    no_vad: Annotated[bool, typer.Option("--no-vad", help="VADによる発話単位分割を無効化")] = False,
     continue_on_overflow: Annotated[
         bool,
         typer.Option("--continue-on-overflow", help="音声取り逃がし時も記録して続行する"),
@@ -139,6 +140,7 @@ def live(
             "summarization.ollama_model": ollama_model,
             "output.save_transcript": _disabled_when(no_save),
             "output.save_audio": _disabled_when(no_save_audio),
+            "vad.enabled": _disabled_when(no_vad),
             "audio.abort_on_overflow": _overflow_abort_setting(
                 continue_on_overflow,
                 abort_on_overflow,

--- a/src/meeting_minutes/config.py
+++ b/src/meeting_minutes/config.py
@@ -31,7 +31,9 @@ class VadConfig(BaseModel):
                 "vad.min_speech_seconds must be less than or equal to max_speech_seconds"
             )
         if frame_seconds > self.max_speech_seconds:
-            raise ValueError("vad.frame_ms must be less than or equal to max_speech_seconds")
+            raise ValueError(
+                "vad.frame_ms converted to seconds must be less than or equal to max_speech_seconds"
+            )
         return self
 
 

--- a/src/meeting_minutes/config.py
+++ b/src/meeting_minutes/config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
+from typing import Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -11,6 +12,27 @@ class AudioConfig(BaseModel):
     channels: int = 1
     chunk_seconds: int = Field(default=8, ge=1)
     abort_on_overflow: bool = True
+
+
+class VadConfig(BaseModel):
+    enabled: bool = True
+    frame_ms: int = Field(default=30, ge=10)
+    speech_threshold: float = Field(default=0.01, gt=0)
+    silence_seconds: float = Field(default=0.8, ge=0)
+    min_speech_seconds: float = Field(default=0.3, ge=0)
+    max_speech_seconds: float = Field(default=15.0, gt=0)
+    padding_seconds: float = Field(default=0.2, ge=0)
+
+    @model_validator(mode="after")
+    def validate_durations(self) -> Self:
+        frame_seconds = self.frame_ms / 1000
+        if self.min_speech_seconds > self.max_speech_seconds:
+            raise ValueError(
+                "vad.min_speech_seconds must be less than or equal to max_speech_seconds"
+            )
+        if frame_seconds > self.max_speech_seconds:
+            raise ValueError("vad.frame_ms must be less than or equal to max_speech_seconds")
+        return self
 
 
 class TranscriptionConfig(BaseModel):
@@ -54,6 +76,7 @@ class AppConfig(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="MEETING_MINUTES_", env_nested_delimiter="__")
 
     audio: AudioConfig = Field(default_factory=AudioConfig)
+    vad: VadConfig = Field(default_factory=VadConfig)
     transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)
     summarization: SummarizationConfig = Field(default_factory=SummarizationConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)
@@ -77,6 +100,7 @@ def load_config(path: Path | None) -> AppConfig:
 def apply_overrides(config: AppConfig, overrides: dict[str, object]) -> AppConfig:
     allowed_sections = {
         "audio",
+        "vad",
         "transcription",
         "summarization",
         "output",

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -14,6 +14,7 @@ from meeting_minutes.config import AppConfig
 from meeting_minutes.dedupe import TranscriptDedupe
 from meeting_minutes.devices import resolve_input_device
 from meeting_minutes.errors import MeetingMinutesError
+from meeting_minutes.live_transcription import SpeechTranscriptionRunner
 from meeting_minutes.metadata import build_metadata, write_metadata
 from meeting_minutes.output import (
     append_transcript_segment,
@@ -23,6 +24,7 @@ from meeting_minutes.output import (
 )
 from meeting_minutes.summarize import generate_minutes
 from meeting_minutes.transcribe import TranscriptionSegment, WhisperTranscriber
+from meeting_minutes.vad import SpeechSegmenter
 from meeting_minutes.vocabulary import build_initial_prompt, load_vocabulary
 
 console = Console()
@@ -31,7 +33,7 @@ AUDIO_RECORDING_ERRORS: tuple[type[Exception], ...] = (OSError, ValueError, wave
 
 
 def _segment_elapsed_range(
-    chunk_start_seconds: int,
+    chunk_start_seconds: float,
     segment: TranscriptionSegment,
 ) -> tuple[int, int]:
     start = floor(chunk_start_seconds + segment.start)
@@ -115,7 +117,7 @@ class TranscriptWriter:
         self,
         segments: list[TranscriptionSegment],
         *,
-        chunk_start_seconds: int,
+        chunk_start_seconds: float,
     ) -> None:
         for segment in segments:
             segment_start, segment_elapsed = _segment_elapsed_range(
@@ -207,7 +209,14 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
         console.print(f"[green]Vocabulary hint:[/green] {len(initial_prompt)} chars")
     transcriber = WhisperTranscriber(config.transcription, initial_prompt=initial_prompt)
     dedupe = TranscriptDedupe()
+    speech_segmenter = SpeechSegmenter(config.vad, sample_rate=config.audio.sample_rate)
     transcript_writer = TranscriptWriter(transcript_path)
+    transcription_runner = SpeechTranscriptionRunner(
+        speech_segmenter=speech_segmenter,
+        transcriber=transcriber,
+        dedupe=dedupe,
+        segment_writer=transcript_writer,
+    )
     overflow_recorder = AudioOverflowRecorder(errors)
     draft_scheduler = DraftScheduler.create(
         draft_interval_minutes=draft_interval_minutes,
@@ -217,6 +226,8 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
         errors=errors,
     )
     elapsed_seconds = 0
+    if config.vad.enabled:
+        console.print("[green]VAD:[/green] enabled")
 
     try:
         audio_recording = AudioRecording.open(
@@ -233,19 +244,14 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
             abort_on_overflow=config.audio.abort_on_overflow,
             on_overflow=overflow_recorder.record,
         ):
-            chunk_start_seconds = elapsed_seconds
             elapsed_seconds += config.audio.chunk_seconds
             audio_recording.write(chunk, errors)
-            segments = transcriber.transcribe_segments(chunk)
-            text = " ".join(segment.text for segment in segments).strip()
-            if not dedupe.should_keep(text):
-                continue
-            transcript_writer.write_segments(
-                segments,
-                chunk_start_seconds=chunk_start_seconds,
-            )
+            if transcription_runner.process(chunk):
+                draft_scheduler.maybe_generate(elapsed_seconds)
+        if transcription_runner.flush():
             draft_scheduler.maybe_generate(elapsed_seconds)
     except KeyboardInterrupt:
+        transcription_runner.flush()
         console.print("\n[yellow]Stopping...[/yellow]")
     except Exception as exc:
         logger.exception("Live session aborted")

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -143,6 +143,7 @@ class DraftScheduler:
     errors: list[str]
     interval_seconds: int
     next_draft_at: int | None
+    last_draft_transcript_size: int
 
     @classmethod
     def create(
@@ -156,6 +157,7 @@ class DraftScheduler:
     ) -> "DraftScheduler":
         interval_seconds = draft_interval_minutes * 60
         next_draft_at = interval_seconds if interval_seconds > 0 else None
+        transcript_size = cls._transcript_size(transcript_path) or 0
         return cls(
             transcript_path=transcript_path,
             session_dir=session_dir,
@@ -163,12 +165,17 @@ class DraftScheduler:
             errors=errors,
             interval_seconds=interval_seconds,
             next_draft_at=next_draft_at,
+            last_draft_transcript_size=transcript_size,
         )
 
     def maybe_generate(self, elapsed_seconds: int) -> None:
         if self.next_draft_at is None or self.transcript_path is None:
             return
         if elapsed_seconds < self.next_draft_at:
+            return
+        transcript_size = self._transcript_size(self.transcript_path)
+        if transcript_size is not None and transcript_size <= self.last_draft_transcript_size:
+            self.next_draft_at += self.interval_seconds
             return
 
         try:
@@ -181,7 +188,19 @@ class DraftScheduler:
         except (MeetingMinutesError, OSError, UnicodeError) as exc:
             logger.exception("Draft generation failed")
             self.errors.append(f"draft generation failed: {exc}")
+        else:
+            if transcript_size is not None:
+                self.last_draft_transcript_size = transcript_size
         self.next_draft_at += self.interval_seconds
+
+    @staticmethod
+    def _transcript_size(transcript_path: Path | None) -> int | None:
+        if transcript_path is None:
+            return None
+        try:
+            return transcript_path.stat().st_size
+        except OSError:
+            return None
 
 
 def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
@@ -246,8 +265,8 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
         ):
             elapsed_seconds += config.audio.chunk_seconds
             audio_recording.write(chunk, errors)
-            if transcription_runner.process(chunk):
-                draft_scheduler.maybe_generate(elapsed_seconds)
+            transcription_runner.process(chunk)
+            draft_scheduler.maybe_generate(elapsed_seconds)
         if transcription_runner.flush():
             draft_scheduler.maybe_generate(elapsed_seconds)
     except KeyboardInterrupt:

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -251,7 +251,8 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
         if transcription_runner.flush():
             draft_scheduler.maybe_generate(elapsed_seconds)
     except KeyboardInterrupt:
-        transcription_runner.flush()
+        if transcription_runner.flush():
+            draft_scheduler.maybe_generate(elapsed_seconds)
         console.print("\n[yellow]Stopping...[/yellow]")
     except Exception as exc:
         logger.exception("Live session aborted")

--- a/src/meeting_minutes/live_transcription.py
+++ b/src/meeting_minutes/live_transcription.py
@@ -1,0 +1,58 @@
+from typing import Protocol
+
+import numpy as np
+
+from meeting_minutes.dedupe import TranscriptDedupe
+from meeting_minutes.transcribe import TranscriptionSegment
+from meeting_minutes.vad import SpeechSegment, SpeechSegmenter
+
+
+class SegmentWriter(Protocol):
+    def write_segments(
+        self,
+        segments: list[TranscriptionSegment],
+        *,
+        chunk_start_seconds: float,
+    ) -> None: ...
+
+
+class SegmentTranscriber(Protocol):
+    def transcribe_segments(self, audio: np.ndarray) -> list[TranscriptionSegment]: ...
+
+
+class SpeechTranscriptionRunner:
+    def __init__(
+        self,
+        *,
+        speech_segmenter: SpeechSegmenter,
+        transcriber: SegmentTranscriber,
+        dedupe: TranscriptDedupe,
+        segment_writer: SegmentWriter,
+    ) -> None:
+        self._speech_segmenter = speech_segmenter
+        self._transcriber = transcriber
+        self._dedupe = dedupe
+        self._segment_writer = segment_writer
+
+    def process(self, chunk: np.ndarray) -> bool:
+        wrote_segments = False
+        for speech_segment in self._speech_segmenter.process(chunk):
+            wrote_segments |= self._transcribe(speech_segment)
+        return wrote_segments
+
+    def flush(self) -> bool:
+        wrote_segments = False
+        for speech_segment in self._speech_segmenter.flush():
+            wrote_segments |= self._transcribe(speech_segment)
+        return wrote_segments
+
+    def _transcribe(self, speech_segment: SpeechSegment) -> bool:
+        segments = self._transcriber.transcribe_segments(speech_segment.audio)
+        text = " ".join(segment.text for segment in segments).strip()
+        if not self._dedupe.should_keep(text):
+            return False
+        self._segment_writer.write_segments(
+            segments,
+            chunk_start_seconds=speech_segment.start_seconds,
+        )
+        return True

--- a/src/meeting_minutes/vad.py
+++ b/src/meeting_minutes/vad.py
@@ -1,0 +1,130 @@
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+import numpy as np
+
+from meeting_minutes.config import VadConfig
+
+
+@dataclass(frozen=True)
+class SpeechSegment:
+    audio: np.ndarray
+    start_seconds: float
+    end_seconds: float
+
+
+class SpeechSegmenter:
+    def __init__(self, config: VadConfig, *, sample_rate: int) -> None:
+        self._config = config
+        self._sample_rate = sample_rate
+        self._frame_samples = max(round(sample_rate * config.frame_ms / 1000), 1)
+        self._silence_frames = max(
+            round(config.silence_seconds * sample_rate / self._frame_samples),
+            1,
+        )
+        self._padding_samples = round(config.padding_seconds * sample_rate)
+        self._min_speech_samples = round(config.min_speech_seconds * sample_rate)
+        self._max_speech_samples = round(config.max_speech_seconds * sample_rate)
+        self._pre_roll = np.empty(0, dtype=np.float32)
+        self._pending_frame = np.empty(0, dtype=np.float32)
+        self._speech_audio = np.empty(0, dtype=np.float32)
+        self._speech_start_sample: int | None = None
+        self._silence_audio = np.empty(0, dtype=np.float32)
+        self._silence_frame_count = 0
+        self._processed_samples = 0
+
+    def process(self, chunk: np.ndarray) -> Iterator[SpeechSegment]:
+        if not self._config.enabled:
+            start = self._processed_samples / self._sample_rate
+            self._processed_samples += chunk.shape[0]
+            yield SpeechSegment(
+                audio=np.asarray(chunk, dtype=np.float32),
+                start_seconds=start,
+                end_seconds=self._processed_samples / self._sample_rate,
+            )
+            return
+
+        mono = np.concatenate((self._pending_frame, np.asarray(chunk, dtype=np.float32)))
+        frame_count = mono.shape[0] // self._frame_samples
+        for index in range(frame_count):
+            start = index * self._frame_samples
+            frame = mono[start : start + self._frame_samples]
+            yield from self._process_frame(frame)
+
+        self._pending_frame = mono[frame_count * self._frame_samples :]
+
+    def flush(self) -> list[SpeechSegment]:
+        segments: list[SpeechSegment] = []
+        if self._pending_frame.size:
+            segments.extend(self._process_frame(self._pending_frame))
+            self._pending_frame = np.empty(0, dtype=np.float32)
+        if self._speech_start_sample is not None:
+            segment = self._finish_speech(include_trailing_silence=True)
+            if segment is not None:
+                segments.append(segment)
+        return segments
+
+    def _process_frame(self, frame: np.ndarray) -> Iterable[SpeechSegment]:
+        is_speech = float(np.sqrt(np.mean(np.square(frame)))) >= self._config.speech_threshold
+        if self._speech_start_sample is None:
+            if is_speech:
+                self._start_speech(frame)
+            else:
+                self._append_pre_roll(frame)
+            self._processed_samples += frame.shape[0]
+            return []
+
+        self._speech_audio = np.concatenate((self._speech_audio, frame))
+        if is_speech:
+            self._silence_audio = np.empty(0, dtype=np.float32)
+            self._silence_frame_count = 0
+        else:
+            self._silence_audio = np.concatenate((self._silence_audio, frame))
+            self._silence_frame_count += 1
+
+        self._processed_samples += frame.shape[0]
+        if self._speech_audio.shape[0] >= self._max_speech_samples:
+            segment = self._finish_speech(include_trailing_silence=True)
+            return [segment] if segment is not None else []
+        if self._silence_frame_count >= self._silence_frames:
+            segment = self._finish_speech(include_trailing_silence=False)
+            return [segment] if segment is not None else []
+        return []
+
+    def _start_speech(self, frame: np.ndarray) -> None:
+        self._speech_start_sample = self._processed_samples - self._pre_roll.shape[0]
+        self._speech_audio = np.concatenate((self._pre_roll, frame))
+        self._pre_roll = np.empty(0, dtype=np.float32)
+        self._silence_audio = np.empty(0, dtype=np.float32)
+        self._silence_frame_count = 0
+
+    def _finish_speech(self, *, include_trailing_silence: bool) -> SpeechSegment | None:
+        if self._speech_start_sample is None:
+            return None
+
+        trailing_silence_samples = 0 if include_trailing_silence else self._silence_audio.shape[0]
+        speech_audio = self._speech_audio[: self._speech_audio.shape[0] - trailing_silence_samples]
+        speech_start_sample = self._speech_start_sample
+        speech_end_sample = speech_start_sample + speech_audio.shape[0]
+        self._pre_roll = (
+            self._speech_audio[-self._padding_samples :]
+            if self._padding_samples
+            else np.empty(0, dtype=np.float32)
+        )
+        self._speech_audio = np.empty(0, dtype=np.float32)
+        self._speech_start_sample = None
+        self._silence_audio = np.empty(0, dtype=np.float32)
+        self._silence_frame_count = 0
+
+        if speech_audio.shape[0] < self._min_speech_samples:
+            return None
+        return SpeechSegment(
+            audio=speech_audio,
+            start_seconds=speech_start_sample / self._sample_rate,
+            end_seconds=speech_end_sample / self._sample_rate,
+        )
+
+    def _append_pre_roll(self, audio: np.ndarray) -> None:
+        if self._padding_samples == 0:
+            return
+        self._pre_roll = np.concatenate((self._pre_roll, audio))[-self._padding_samples :]

--- a/src/meeting_minutes/vad.py
+++ b/src/meeting_minutes/vad.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
+from math import ceil
 
 import numpy as np
 
@@ -17,20 +18,21 @@ class SpeechSegmenter:
     def __init__(self, config: VadConfig, *, sample_rate: int) -> None:
         self._config = config
         self._sample_rate = sample_rate
-        self._frame_samples = max(round(sample_rate * config.frame_ms / 1000), 1)
+        self._frame_samples = max(ceil(sample_rate * config.frame_ms / 1000), 1)
         self._silence_frames = max(
-            round(config.silence_seconds * sample_rate / self._frame_samples),
+            ceil(config.silence_seconds * sample_rate / self._frame_samples),
             1,
         )
-        self._padding_samples = round(config.padding_seconds * sample_rate)
-        self._min_speech_samples = round(config.min_speech_seconds * sample_rate)
-        self._max_speech_samples = round(config.max_speech_seconds * sample_rate)
+        self._padding_samples = ceil(config.padding_seconds * sample_rate)
+        self._min_speech_samples = ceil(config.min_speech_seconds * sample_rate)
+        self._max_speech_samples = ceil(config.max_speech_seconds * sample_rate)
         self._pre_roll = np.empty(0, dtype=np.float32)
         self._pending_frame = np.empty(0, dtype=np.float32)
-        self._speech_audio = np.empty(0, dtype=np.float32)
+        self._speech_frames: list[np.ndarray] = []
         self._speech_start_sample: int | None = None
-        self._silence_audio = np.empty(0, dtype=np.float32)
+        self._silence_samples = 0
         self._silence_frame_count = 0
+        self._speech_samples = 0
         self._processed_samples = 0
 
     def process(self, chunk: np.ndarray) -> Iterator[SpeechSegment]:
@@ -74,16 +76,17 @@ class SpeechSegmenter:
             self._processed_samples += frame.shape[0]
             return []
 
-        self._speech_audio = np.concatenate((self._speech_audio, frame))
+        self._speech_frames.append(frame)
+        self._speech_samples += frame.shape[0]
         if is_speech:
-            self._silence_audio = np.empty(0, dtype=np.float32)
+            self._silence_samples = 0
             self._silence_frame_count = 0
         else:
-            self._silence_audio = np.concatenate((self._silence_audio, frame))
+            self._silence_samples += frame.shape[0]
             self._silence_frame_count += 1
 
         self._processed_samples += frame.shape[0]
-        if self._speech_audio.shape[0] >= self._max_speech_samples:
+        if self._speech_samples >= self._max_speech_samples:
             segment = self._finish_speech(include_trailing_silence=True)
             return [segment] if segment is not None else []
         if self._silence_frame_count >= self._silence_frames:
@@ -93,28 +96,36 @@ class SpeechSegmenter:
 
     def _start_speech(self, frame: np.ndarray) -> None:
         self._speech_start_sample = self._processed_samples - self._pre_roll.shape[0]
-        self._speech_audio = np.concatenate((self._pre_roll, frame))
+        self._speech_frames = [self._pre_roll, frame] if self._pre_roll.size else [frame]
+        self._speech_samples = self._pre_roll.shape[0] + frame.shape[0]
         self._pre_roll = np.empty(0, dtype=np.float32)
-        self._silence_audio = np.empty(0, dtype=np.float32)
+        self._silence_samples = 0
         self._silence_frame_count = 0
 
     def _finish_speech(self, *, include_trailing_silence: bool) -> SpeechSegment | None:
         if self._speech_start_sample is None:
             return None
 
-        trailing_silence_samples = 0 if include_trailing_silence else self._silence_audio.shape[0]
-        speech_audio = self._speech_audio[: self._speech_audio.shape[0] - trailing_silence_samples]
+        speech_audio = (
+            np.concatenate(self._speech_frames)
+            if self._speech_frames
+            else np.empty(0, dtype=np.float32)
+        )
+        trailing_silence_samples = 0 if include_trailing_silence else self._silence_samples
+        if trailing_silence_samples:
+            speech_audio = speech_audio[: speech_audio.shape[0] - trailing_silence_samples]
         speech_start_sample = self._speech_start_sample
         speech_end_sample = speech_start_sample + speech_audio.shape[0]
         self._pre_roll = (
-            self._speech_audio[-self._padding_samples :]
+            speech_audio[-self._padding_samples :]
             if self._padding_samples
             else np.empty(0, dtype=np.float32)
         )
-        self._speech_audio = np.empty(0, dtype=np.float32)
+        self._speech_frames = []
         self._speech_start_sample = None
-        self._silence_audio = np.empty(0, dtype=np.float32)
+        self._silence_samples = 0
         self._silence_frame_count = 0
+        self._speech_samples = 0
 
         if speech_audio.shape[0] < self._min_speech_samples:
             return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from meeting_minutes.config import apply_overrides, load_config
+from meeting_minutes.config import VadConfig, apply_overrides, load_config
 
 
 def test_load_config_from_toml(tmp_path: Path) -> None:
@@ -63,3 +63,13 @@ def test_apply_overrides_updates_multiple_sections() -> None:
 def test_apply_overrides_raises_for_unknown_section() -> None:
     with pytest.raises(ValueError, match="Unsupported override section 'unknown'"):
         apply_overrides(load_config(None), {"unknown.value": "ignored"})
+
+
+def test_vad_config_rejects_min_speech_longer_than_max() -> None:
+    with pytest.raises(ValueError, match="min_speech_seconds"):
+        VadConfig(min_speech_seconds=10, max_speech_seconds=3)
+
+
+def test_vad_config_rejects_frame_longer_than_max() -> None:
+    with pytest.raises(ValueError, match="frame_ms"):
+        VadConfig(frame_ms=500, max_speech_seconds=0.1)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -8,7 +8,7 @@ import pytest
 from meeting_minutes.audio_stream import AudioOverflowError
 from meeting_minutes.config import AppConfig, AudioConfig, OutputConfig
 from meeting_minutes.devices import InputDevice
-from meeting_minutes.live import _segment_elapsed_range, run_live
+from meeting_minutes.live import DraftScheduler, _segment_elapsed_range, run_live
 from meeting_minutes.transcribe import TranscriptionSegment
 
 
@@ -64,6 +64,39 @@ def test_segment_elapsed_range_encloses_segment_times() -> None:
     segment = TranscriptionSegment(start=0.51, end=1.49, text="hello")
 
     assert _segment_elapsed_range(10, segment) == (10, 12)
+
+
+def test_draft_scheduler_generates_when_transcript_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transcript_path = tmp_path / "transcript_live.md"
+    transcript_path.write_text("# transcript\n", encoding="utf-8")
+    calls: list[Path] = []
+
+    def fake_generate_minutes(
+        transcript_file: Path,
+        _mode: object,
+        _output: object,
+        _config: object,
+    ) -> Path:
+        calls.append(transcript_file)
+        return tmp_path / "minutes_draft.md"
+
+    monkeypatch.setattr("meeting_minutes.live.generate_minutes", fake_generate_minutes)
+    scheduler = DraftScheduler.create(
+        draft_interval_minutes=1,
+        transcript_path=transcript_path,
+        session_dir=tmp_path,
+        config=live_config(tmp_path),
+        errors=[],
+    )
+
+    transcript_path.write_text("# transcript\nhello\n", encoding="utf-8")
+    scheduler.maybe_generate(60)
+    scheduler.maybe_generate(120)
+
+    assert calls == [transcript_path]
 
 
 def test_run_live_writes_audio_and_transcript(

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -26,7 +26,7 @@ def input_device() -> InputDevice:
 @pytest.fixture
 def single_chunk_audio(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
-        yield np.zeros(16000, dtype=np.float32)
+        yield np.full(16000, 0.1, dtype=np.float32)
 
     monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
 
@@ -164,7 +164,7 @@ def test_run_live_continues_and_records_audio_overflow_when_configured(
         assert callable(on_overflow)
         on_overflow(1)
         on_overflow(2)
-        yield np.zeros(16000, dtype=np.float32)
+        yield np.full(16000, 0.1, dtype=np.float32)
 
     monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
     monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)

--- a/tests/test_live_transcription.py
+++ b/tests/test_live_transcription.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+from meeting_minutes.config import VadConfig
+from meeting_minutes.dedupe import TranscriptDedupe
+from meeting_minutes.live_transcription import SpeechTranscriptionRunner
+from meeting_minutes.transcribe import TranscriptionSegment
+from meeting_minutes.vad import SpeechSegmenter
+
+
+class FakeTranscriber:
+    def transcribe_segments(self, _audio: np.ndarray) -> list[TranscriptionSegment]:
+        return [TranscriptionSegment(start=0, end=0.2, text="hello")]
+
+
+class SegmentCollector:
+    def __init__(self) -> None:
+        self.calls: list[tuple[float, list[TranscriptionSegment]]] = []
+
+    def write_segments(
+        self,
+        segments: list[TranscriptionSegment],
+        *,
+        chunk_start_seconds: float,
+    ) -> None:
+        self.calls.append((chunk_start_seconds, segments))
+
+
+def test_speech_transcription_runner_writes_detected_speech() -> None:
+    collector = SegmentCollector()
+    runner = SpeechTranscriptionRunner(
+        speech_segmenter=SpeechSegmenter(
+            VadConfig(
+                frame_ms=100,
+                silence_seconds=0.2,
+                min_speech_seconds=0.1,
+                padding_seconds=0,
+            ),
+            sample_rate=10,
+        ),
+        transcriber=FakeTranscriber(),
+        dedupe=TranscriptDedupe(),
+        segment_writer=collector,
+    )
+
+    wrote_during_process = runner.process(
+        np.concatenate((np.full(2, 0.1, dtype=np.float32), np.zeros(3, dtype=np.float32)))
+    )
+
+    assert wrote_during_process
+    assert len(collector.calls) == 1
+    assert collector.calls[0][0] == 0
+    assert collector.calls[0][1][0].text == "hello"
+
+
+def test_speech_transcription_runner_flushes_pending_speech() -> None:
+    collector = SegmentCollector()
+    runner = SpeechTranscriptionRunner(
+        speech_segmenter=SpeechSegmenter(
+            VadConfig(frame_ms=100, min_speech_seconds=0.1, padding_seconds=0),
+            sample_rate=10,
+        ),
+        transcriber=FakeTranscriber(),
+        dedupe=TranscriptDedupe(),
+        segment_writer=collector,
+    )
+
+    assert not runner.process(np.full(2, 0.1, dtype=np.float32))
+    assert runner.flush()
+    assert len(collector.calls) == 1
+
+
+def test_speech_transcription_runner_passthrough_when_vad_is_disabled() -> None:
+    collector = SegmentCollector()
+    runner = SpeechTranscriptionRunner(
+        speech_segmenter=SpeechSegmenter(VadConfig(enabled=False), sample_rate=10),
+        transcriber=FakeTranscriber(),
+        dedupe=TranscriptDedupe(),
+        segment_writer=collector,
+    )
+
+    assert runner.process(np.full(2, 0.1, dtype=np.float32))
+    assert len(collector.calls) == 1
+    assert collector.calls[0][0] == 0

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -32,6 +32,33 @@ def test_speech_segmenter_emits_speech_after_trailing_silence() -> None:
     assert np.allclose(segments[0].audio, [0.0, 0.1, 0.1, 0.1, 0.1])
 
 
+def test_speech_segmenter_pre_roll_excludes_trailing_silence() -> None:
+    segmenter = SpeechSegmenter(
+        VadConfig(
+            frame_ms=100,
+            speech_threshold=0.01,
+            silence_seconds=0.2,
+            min_speech_seconds=0.1,
+            max_speech_seconds=5,
+            padding_seconds=0.2,
+        ),
+        sample_rate=10,
+    )
+    audio = np.concatenate(
+        (
+            np.full(3, 0.1, dtype=np.float32),
+            np.zeros(2, dtype=np.float32),
+            np.full(2, 0.1, dtype=np.float32),
+            np.zeros(2, dtype=np.float32),
+        )
+    )
+
+    segments = list(segmenter.process(audio))
+
+    assert len(segments) == 2
+    assert np.allclose(segments[1].audio, [0.1, 0.1, 0.1, 0.1])
+
+
 def test_speech_segmenter_forces_split_when_speech_is_too_long() -> None:
     segmenter = SpeechSegmenter(
         VadConfig(

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,0 +1,121 @@
+import numpy as np
+
+from meeting_minutes.config import VadConfig
+from meeting_minutes.vad import SpeechSegmenter
+
+
+def test_speech_segmenter_emits_speech_after_trailing_silence() -> None:
+    segmenter = SpeechSegmenter(
+        VadConfig(
+            frame_ms=100,
+            speech_threshold=0.01,
+            silence_seconds=0.2,
+            min_speech_seconds=0.2,
+            max_speech_seconds=5,
+            padding_seconds=0.1,
+        ),
+        sample_rate=10,
+    )
+    audio = np.concatenate(
+        (
+            np.zeros(2, dtype=np.float32),
+            np.full(4, 0.1, dtype=np.float32),
+            np.zeros(3, dtype=np.float32),
+        )
+    )
+
+    segments = list(segmenter.process(audio))
+
+    assert len(segments) == 1
+    assert segments[0].start_seconds == 0.1
+    assert segments[0].end_seconds == 0.6
+    assert np.allclose(segments[0].audio, [0.0, 0.1, 0.1, 0.1, 0.1])
+
+
+def test_speech_segmenter_forces_split_when_speech_is_too_long() -> None:
+    segmenter = SpeechSegmenter(
+        VadConfig(
+            frame_ms=100,
+            speech_threshold=0.01,
+            silence_seconds=0.5,
+            min_speech_seconds=0.1,
+            max_speech_seconds=0.3,
+            padding_seconds=0,
+        ),
+        sample_rate=10,
+    )
+
+    segments = list(segmenter.process(np.full(5, 0.1, dtype=np.float32)))
+
+    assert [(segment.start_seconds, segment.end_seconds) for segment in segments] == [(0.0, 0.3)]
+
+
+def test_speech_segmenter_drops_short_noise() -> None:
+    segmenter = SpeechSegmenter(
+        VadConfig(
+            frame_ms=100,
+            speech_threshold=0.01,
+            silence_seconds=0.2,
+            min_speech_seconds=0.5,
+            max_speech_seconds=5,
+            padding_seconds=0,
+        ),
+        sample_rate=10,
+    )
+    audio = np.concatenate((np.full(2, 0.1, dtype=np.float32), np.zeros(3, dtype=np.float32)))
+
+    assert list(segmenter.process(audio)) == []
+
+
+def test_speech_segmenter_carries_partial_frames_across_chunks() -> None:
+    segmenter = SpeechSegmenter(
+        VadConfig(
+            frame_ms=100,
+            speech_threshold=0.01,
+            silence_seconds=0.2,
+            min_speech_seconds=0.1,
+            max_speech_seconds=5,
+            padding_seconds=0,
+        ),
+        sample_rate=10,
+    )
+
+    assert list(segmenter.process(np.array([0.1], dtype=np.float32))) == []
+    assert list(segmenter.process(np.array([0.1], dtype=np.float32))) == []
+    segments = segmenter.flush()
+
+    assert len(segments) == 1
+    segment = segments[0]
+    assert segment.start_seconds == 0
+    assert segment.end_seconds == 0.2
+    assert np.allclose(segment.audio, [0.1, 0.1])
+
+
+def test_speech_segmenter_flush_returns_pending_segments_as_list() -> None:
+    segmenter = SpeechSegmenter(
+        VadConfig(
+            frame_ms=200,
+            speech_threshold=0.01,
+            silence_seconds=0.2,
+            min_speech_seconds=0.1,
+            max_speech_seconds=1.0,
+            padding_seconds=0,
+        ),
+        sample_rate=10,
+    )
+    assert list(segmenter.process(np.array([0.1], dtype=np.float32))) == []
+
+    segments = segmenter.flush()
+
+    assert [(segment.start_seconds, segment.end_seconds) for segment in segments] == [(0.0, 0.1)]
+
+
+def test_speech_segmenter_passthrough_when_disabled() -> None:
+    segmenter = SpeechSegmenter(VadConfig(enabled=False), sample_rate=10)
+
+    segments = list(segmenter.process(np.arange(5, dtype=np.float32)))
+
+    assert len(segments) == 1
+    assert segments[0].start_seconds == 0
+    assert segments[0].end_seconds == 0.5
+    assert np.array_equal(segments[0].audio, np.arange(5, dtype=np.float32))


### PR DESCRIPTION
## Summary
- Add configurable local VAD settings and a lightweight speech segmenter
- Route `live` transcription through a dedicated runner so segments are transcribed by speech boundaries instead of fixed chunks
- Add `--no-vad` to fall back to the previous chunk-based flow
- Update docs, config example, and tests for VAD, runner behavior, and config validation

Close #7 

## Testing
- Added unit coverage for VAD segmentation, flush behavior, passthrough mode, and runner integration
- Added config validation tests for invalid VAD duration settings
- Local lint, type-check, and test suite checks passed