### PR TITLE
[codex] Improve ASR pipeline quality

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -16,11 +16,25 @@ min_speech_seconds = 0.3
 max_speech_seconds = 15.0
 padding_seconds = 0.2
 
+[preprocessing]
+enabled = false
+normalize_peak = true
+target_peak = 0.8
+noise_gate_enabled = false
+noise_gate_threshold = 0.003
+
 [transcription]
 whisper_model = "small"
 language = "ja"
 device = "cpu"
 compute_type = "int8"
+
+[transcript_filter]
+enabled = true
+canned_false_positives = ["Thank you.", "Thanks for watching.", "Bye."]
+min_text_chars = 0
+max_repeat_pattern_chars = 8
+min_repeat_count = 4
 
 [summarization]
 ollama_base_url = "http://localhost:11434"
@@ -45,5 +59,8 @@ chunk_overlap = 500
 # participants_file = "vocab/participants.txt"
 # Whisper の initial_prompt 上限（約224 token）に収めるための文字数上限。0 でヒント無効。
 max_prompt_chars = 200
+# 直近の採用済み文字起こしを initial_prompt に混ぜる。誤認識の持ち越しを避けるためデフォルトは無効。
+dynamic_context_enabled = false
+dynamic_context_chars = 120
 # 要約プロンプトへの語彙注入の文字数上限。上限を超える語彙は末尾から項目単位で切り落とす。0 で無効。
 max_summary_chars = 1000

--- a/src/meeting_minutes/__init__.py
+++ b/src/meeting_minutes/__init__.py
@@ -1,3 +1,3 @@
 """Local realtime transcription and meeting minutes CLI."""
 
-__version__ = "0.3.0"
+__version__ = "0.2.0"

--- a/src/meeting_minutes/config.py
+++ b/src/meeting_minutes/config.py
@@ -37,11 +37,33 @@ class VadConfig(BaseModel):
         return self
 
 
+class PreprocessingConfig(BaseModel):
+    enabled: bool = False
+    normalize_peak: bool = True
+    target_peak: float = Field(default=0.8, gt=0, le=1.0)
+    noise_gate_enabled: bool = False
+    noise_gate_threshold: float = Field(default=0.003, ge=0)
+
+
 class TranscriptionConfig(BaseModel):
     whisper_model: str = "small"
     language: str = "ja"
     device: str = "cpu"
     compute_type: str = "int8"
+
+
+class TranscriptFilterConfig(BaseModel):
+    enabled: bool = True
+    canned_false_positives: list[str] = Field(
+        default_factory=lambda: [
+            "Thank you.",
+            "Thanks for watching.",
+            "Bye.",
+        ],
+    )
+    min_text_chars: int = Field(default=0, ge=0)
+    max_repeat_pattern_chars: int = Field(default=8, ge=1)
+    min_repeat_count: int = Field(default=4, ge=2)
 
 
 class SummarizationConfig(BaseModel):
@@ -69,6 +91,8 @@ class VocabularyConfig(BaseModel):
     # Whisper の initial_prompt は約 224 token が上限。日本語では 1 文字 ≒ 1〜2 token のため、
     # 200 文字を安全側のデフォルトとする。
     max_prompt_chars: int = Field(default=200, ge=0)
+    dynamic_context_enabled: bool = False
+    dynamic_context_chars: int = Field(default=120, ge=0)
     # 要約プロンプトへの語彙注入上限。Ollama の num_ctx を圧迫しないよう項目単位で切り落とす。
     # 0 で語彙セクションを無効化する。
     max_summary_chars: int = Field(default=1000, ge=0)
@@ -79,7 +103,9 @@ class AppConfig(BaseSettings):
 
     audio: AudioConfig = Field(default_factory=AudioConfig)
     vad: VadConfig = Field(default_factory=VadConfig)
+    preprocessing: PreprocessingConfig = Field(default_factory=PreprocessingConfig)
     transcription: TranscriptionConfig = Field(default_factory=TranscriptionConfig)
+    transcript_filter: TranscriptFilterConfig = Field(default_factory=TranscriptFilterConfig)
     summarization: SummarizationConfig = Field(default_factory=SummarizationConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)
     chunking: ChunkingConfig = Field(default_factory=ChunkingConfig)
@@ -103,7 +129,9 @@ def apply_overrides(config: AppConfig, overrides: dict[str, object]) -> AppConfi
     allowed_sections = {
         "audio",
         "vad",
+        "preprocessing",
         "transcription",
+        "transcript_filter",
         "summarization",
         "output",
         "chunking",

--- a/src/meeting_minutes/dedupe.py
+++ b/src/meeting_minutes/dedupe.py
@@ -1,9 +1,17 @@
 from collections import deque
 from difflib import SequenceMatcher
 
+from meeting_minutes.transcript_filter import TranscriptFilterStats, normalize_transcript_text
+
 
 class TranscriptDedupe:
-    def __init__(self, similarity_threshold: float = 0.92, max_seen: int = 300) -> None:
+    def __init__(
+        self,
+        similarity_threshold: float = 0.92,
+        max_seen: int = 300,
+        *,
+        stats: TranscriptFilterStats | None = None,
+    ) -> None:
         if max_seen < 1:
             raise ValueError("max_seen must be greater than or equal to 1")
         self._seen: set[str] = set()
@@ -11,16 +19,20 @@ class TranscriptDedupe:
         self._last_text = ""
         self._similarity_threshold = similarity_threshold
         self._max_seen = max_seen
+        self._stats = stats
 
     def should_keep(self, text: str) -> bool:
-        normalized = " ".join(text.split())
+        normalized = normalize_transcript_text(text)
         if not normalized:
+            self._record("blank")
             return False
         if normalized in self._seen:
+            self._record("duplicate")
             return False
         if self._last_text:
             ratio = SequenceMatcher(None, self._last_text, normalized).ratio()
             if ratio >= self._similarity_threshold:
+                self._record("similar_duplicate")
                 return False
         self._remember(normalized)
         self._last_text = normalized
@@ -31,3 +43,7 @@ class TranscriptDedupe:
         self._history.append(text)
         while len(self._history) > self._max_seen:
             self._seen.remove(self._history.popleft())
+
+    def _record(self, reason: str) -> None:
+        if self._stats is not None:
+            self._stats.record(reason)

--- a/src/meeting_minutes/dedupe.py
+++ b/src/meeting_minutes/dedupe.py
@@ -1,7 +1,7 @@
 from collections import deque
 from difflib import SequenceMatcher
 
-from meeting_minutes.transcript_filter import TranscriptFilterStats, normalize_transcript_text
+from meeting_minutes.transcript_filter import TranscriptRejectionStats, normalize_transcript_text
 
 
 class TranscriptDedupe:
@@ -10,7 +10,7 @@ class TranscriptDedupe:
         similarity_threshold: float = 0.92,
         max_seen: int = 300,
         *,
-        stats: TranscriptFilterStats | None = None,
+        stats: TranscriptRejectionStats | None = None,
     ) -> None:
         if max_seen < 1:
             raise ValueError("max_seen must be greater than or equal to 1")

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -25,7 +25,7 @@ from meeting_minutes.output import (
 from meeting_minutes.preprocess import AudioPreprocessor
 from meeting_minutes.summarize import generate_minutes
 from meeting_minutes.transcribe import TranscriptionSegment, WhisperTranscriber
-from meeting_minutes.transcript_filter import TranscriptFilter, TranscriptFilterStats
+from meeting_minutes.transcript_filter import TranscriptFilter, TranscriptRejectionStats
 from meeting_minutes.vad import SpeechSegmenter
 from meeting_minutes.vocabulary import (
     RecentTranscriptContext,
@@ -254,9 +254,9 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
     if initial_prompt:
         console.print(f"[green]Vocabulary hint:[/green] {len(initial_prompt)} chars")
     transcriber = WhisperTranscriber(config.transcription, initial_prompt=initial_prompt)
-    filter_stats = TranscriptFilterStats()
-    transcript_filter = TranscriptFilter(config.transcript_filter, stats=filter_stats)
-    dedupe = TranscriptDedupe(stats=filter_stats)
+    rejection_stats = TranscriptRejectionStats()
+    transcript_filter = TranscriptFilter(config.transcript_filter, stats=rejection_stats)
+    dedupe = TranscriptDedupe(stats=rejection_stats)
     speech_segmenter = SpeechSegmenter(config.vad, sample_rate=config.audio.sample_rate)
     prompt_context = (
         DynamicPromptContext(
@@ -332,7 +332,7 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
             transcript_path=transcript_path,
             audio_path=audio_recording.path,
             errors=errors,
-            transcript_filter=filter_stats.as_dict(),
+            transcript_rejections=rejection_stats.as_dict(),
         )
         write_metadata(session_dir / "metadata.json", metadata)
         console.print(f"[green]Metadata saved:[/green] {session_dir / 'metadata.json'}")

--- a/src/meeting_minutes/live.py
+++ b/src/meeting_minutes/live.py
@@ -22,10 +22,18 @@ from meeting_minutes.output import (
     format_elapsed,
     init_transcript,
 )
+from meeting_minutes.preprocess import AudioPreprocessor
 from meeting_minutes.summarize import generate_minutes
 from meeting_minutes.transcribe import TranscriptionSegment, WhisperTranscriber
+from meeting_minutes.transcript_filter import TranscriptFilter, TranscriptFilterStats
 from meeting_minutes.vad import SpeechSegmenter
-from meeting_minutes.vocabulary import build_initial_prompt, load_vocabulary
+from meeting_minutes.vocabulary import (
+    RecentTranscriptContext,
+    Vocabulary,
+    build_contextual_initial_prompt,
+    build_initial_prompt,
+    load_vocabulary,
+)
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -107,6 +115,25 @@ class AudioOverflowRecorder:
         if self.events == 1 or self.events % 10 == 0:
             logger.warning(message)
             console.print(f"[yellow]{message} 続行します。[/yellow]")
+
+
+@dataclass
+class DynamicPromptContext:
+    vocabulary: Vocabulary
+    max_prompt_chars: int
+    recent_context_chars: int
+    recent_context: RecentTranscriptContext
+
+    def build(self) -> str | None:
+        return build_contextual_initial_prompt(
+            self.vocabulary,
+            recent_context=self.recent_context.text,
+            max_chars=self.max_prompt_chars,
+            recent_context_chars=self.recent_context_chars,
+        )
+
+    def append(self, text: str) -> None:
+        self.recent_context.append(text)
 
 
 @dataclass
@@ -227,15 +254,32 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
     if initial_prompt:
         console.print(f"[green]Vocabulary hint:[/green] {len(initial_prompt)} chars")
     transcriber = WhisperTranscriber(config.transcription, initial_prompt=initial_prompt)
-    dedupe = TranscriptDedupe()
+    filter_stats = TranscriptFilterStats()
+    transcript_filter = TranscriptFilter(config.transcript_filter, stats=filter_stats)
+    dedupe = TranscriptDedupe(stats=filter_stats)
     speech_segmenter = SpeechSegmenter(config.vad, sample_rate=config.audio.sample_rate)
+    prompt_context = (
+        DynamicPromptContext(
+            vocabulary=vocabulary,
+            max_prompt_chars=config.vocabulary.max_prompt_chars,
+            recent_context_chars=config.vocabulary.dynamic_context_chars,
+            recent_context=RecentTranscriptContext(
+                max_chars=config.vocabulary.dynamic_context_chars,
+            ),
+        )
+        if config.vocabulary.dynamic_context_enabled
+        else None
+    )
     transcript_writer = TranscriptWriter(transcript_path)
     transcription_runner = SpeechTranscriptionRunner(
         speech_segmenter=speech_segmenter,
         transcriber=transcriber,
         dedupe=dedupe,
+        transcript_filter=transcript_filter,
         segment_writer=transcript_writer,
+        prompt_context=prompt_context,
     )
+    audio_preprocessor = AudioPreprocessor(config.preprocessing)
     overflow_recorder = AudioOverflowRecorder(errors)
     draft_scheduler = DraftScheduler.create(
         draft_interval_minutes=draft_interval_minutes,
@@ -265,7 +309,7 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
         ):
             elapsed_seconds += config.audio.chunk_seconds
             audio_recording.write(chunk, errors)
-            transcription_runner.process(chunk)
+            transcription_runner.process(audio_preprocessor.process(chunk))
             draft_scheduler.maybe_generate(elapsed_seconds)
         if transcription_runner.flush():
             draft_scheduler.maybe_generate(elapsed_seconds)
@@ -288,6 +332,7 @@ def run_live(config: AppConfig, *, draft_interval_minutes: int = 0) -> None:
             transcript_path=transcript_path,
             audio_path=audio_recording.path,
             errors=errors,
+            transcript_filter=filter_stats.as_dict(),
         )
         write_metadata(session_dir / "metadata.json", metadata)
         console.print(f"[green]Metadata saved:[/green] {session_dir / 'metadata.json'}")

--- a/src/meeting_minutes/live_transcription.py
+++ b/src/meeting_minutes/live_transcription.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from meeting_minutes.dedupe import TranscriptDedupe
 from meeting_minutes.transcribe import TranscriptionSegment
+from meeting_minutes.transcript_filter import TranscriptFilter
 from meeting_minutes.vad import SpeechSegment, SpeechSegmenter
 
 
@@ -17,7 +18,18 @@ class SegmentWriter(Protocol):
 
 
 class SegmentTranscriber(Protocol):
-    def transcribe_segments(self, audio: np.ndarray) -> list[TranscriptionSegment]: ...
+    def transcribe_segments(
+        self,
+        audio: np.ndarray,
+        *,
+        initial_prompt: str | None = None,
+    ) -> list[TranscriptionSegment]: ...
+
+
+class PromptContext(Protocol):
+    def build(self) -> str | None: ...
+
+    def append(self, text: str) -> None: ...
 
 
 class SpeechTranscriptionRunner:
@@ -27,12 +39,16 @@ class SpeechTranscriptionRunner:
         speech_segmenter: SpeechSegmenter,
         transcriber: SegmentTranscriber,
         dedupe: TranscriptDedupe,
+        transcript_filter: TranscriptFilter,
         segment_writer: SegmentWriter,
+        prompt_context: PromptContext | None = None,
     ) -> None:
         self._speech_segmenter = speech_segmenter
         self._transcriber = transcriber
         self._dedupe = dedupe
+        self._transcript_filter = transcript_filter
         self._segment_writer = segment_writer
+        self._prompt_context = prompt_context
 
     def process(self, chunk: np.ndarray) -> bool:
         wrote_segments = False
@@ -47,12 +63,20 @@ class SpeechTranscriptionRunner:
         return wrote_segments
 
     def _transcribe(self, speech_segment: SpeechSegment) -> bool:
-        segments = self._transcriber.transcribe_segments(speech_segment.audio)
+        initial_prompt = self._prompt_context.build() if self._prompt_context else None
+        segments = self._transcriber.transcribe_segments(
+            speech_segment.audio,
+            initial_prompt=initial_prompt,
+        )
         text = " ".join(segment.text for segment in segments).strip()
+        if not self._transcript_filter.should_keep(text):
+            return False
         if not self._dedupe.should_keep(text):
             return False
         self._segment_writer.write_segments(
             segments,
             chunk_start_seconds=speech_segment.start_seconds,
         )
+        if self._prompt_context:
+            self._prompt_context.append(text)
         return True

--- a/src/meeting_minutes/metadata.py
+++ b/src/meeting_minutes/metadata.py
@@ -20,7 +20,7 @@ class SessionMetadata(BaseModel):
     language: str
     transcript_path: Path | None
     audio_path: Path | None
-    transcript_filter: dict[str, int | dict[str, int]]
+    transcript_rejections: dict[str, int | dict[str, int]]
     errors: list[str]
     processing_seconds: float | None = None
 
@@ -34,7 +34,7 @@ def build_metadata(
     transcript_path: Path | None,
     audio_path: Path | None,
     errors: list[str],
-    transcript_filter: dict[str, int | dict[str, int]] | None = None,
+    transcript_rejections: dict[str, int | dict[str, int]] | None = None,
 ) -> SessionMetadata:
     processing_seconds = (ended_at - started_at).total_seconds() if ended_at else None
     return SessionMetadata(
@@ -49,7 +49,7 @@ def build_metadata(
         language=config.transcription.language,
         transcript_path=transcript_path,
         audio_path=audio_path,
-        transcript_filter=transcript_filter or {"total": 0, "by_reason": {}},
+        transcript_rejections=transcript_rejections or {"total": 0, "by_reason": {}},
         errors=errors,
         processing_seconds=processing_seconds,
     )

--- a/src/meeting_minutes/metadata.py
+++ b/src/meeting_minutes/metadata.py
@@ -20,6 +20,7 @@ class SessionMetadata(BaseModel):
     language: str
     transcript_path: Path | None
     audio_path: Path | None
+    transcript_filter: dict[str, int | dict[str, int]]
     errors: list[str]
     processing_seconds: float | None = None
 
@@ -33,6 +34,7 @@ def build_metadata(
     transcript_path: Path | None,
     audio_path: Path | None,
     errors: list[str],
+    transcript_filter: dict[str, int | dict[str, int]] | None = None,
 ) -> SessionMetadata:
     processing_seconds = (ended_at - started_at).total_seconds() if ended_at else None
     return SessionMetadata(
@@ -47,6 +49,7 @@ def build_metadata(
         language=config.transcription.language,
         transcript_path=transcript_path,
         audio_path=audio_path,
+        transcript_filter=transcript_filter or {"total": 0, "by_reason": {}},
         errors=errors,
         processing_seconds=processing_seconds,
     )

--- a/src/meeting_minutes/preprocess.py
+++ b/src/meeting_minutes/preprocess.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from meeting_minutes.config import PreprocessingConfig
+
+
+class AudioPreprocessor:
+    def __init__(self, config: PreprocessingConfig) -> None:
+        self._config = config
+
+    def process(self, audio: np.ndarray) -> np.ndarray:
+        processed = np.asarray(audio, dtype=np.float32)
+        if not self._config.enabled:
+            return processed
+
+        if self._config.noise_gate_enabled:
+            processed = self._noise_gate(processed)
+        if self._config.normalize_peak:
+            processed = self._normalize_peak(processed)
+        return processed
+
+    def _noise_gate(self, audio: np.ndarray) -> np.ndarray:
+        if audio.size == 0:
+            return audio
+        return np.where(np.abs(audio) < self._config.noise_gate_threshold, 0.0, audio).astype(
+            np.float32,
+            copy=False,
+        )
+
+    def _normalize_peak(self, audio: np.ndarray) -> np.ndarray:
+        if audio.size == 0:
+            return audio
+        peak = float(np.max(np.abs(audio)))
+        if peak <= 0:
+            return audio
+        gain = self._config.target_peak / peak
+        return np.clip(audio * gain, -1.0, 1.0).astype(np.float32, copy=False)

--- a/src/meeting_minutes/preprocess.py
+++ b/src/meeting_minutes/preprocess.py
@@ -21,16 +21,17 @@ class AudioPreprocessor:
     def _noise_gate(self, audio: np.ndarray) -> np.ndarray:
         if audio.size == 0:
             return audio
-        return np.where(np.abs(audio) < self._config.noise_gate_threshold, 0.0, audio).astype(
-            np.float32,
-            copy=False,
-        )
+        threshold = np.float32(self._config.noise_gate_threshold)
+        return np.where(np.abs(audio) < threshold, np.float32(0.0), audio)
 
     def _normalize_peak(self, audio: np.ndarray) -> np.ndarray:
         if audio.size == 0:
             return audio
-        peak = float(np.max(np.abs(audio)))
+        peak = np.max(np.abs(audio))
         if peak <= 0:
             return audio
-        gain = self._config.target_peak / peak
-        return np.clip(audio * gain, -1.0, 1.0).astype(np.float32, copy=False)
+        gain = np.float32(self._config.target_peak) / peak
+        processed = np.empty_like(audio)
+        np.multiply(audio, gain, out=processed)
+        np.clip(processed, np.float32(-1.0), np.float32(1.0), out=processed)
+        return processed

--- a/src/meeting_minutes/transcribe.py
+++ b/src/meeting_minutes/transcribe.py
@@ -33,17 +33,29 @@ class WhisperTranscriber:
         self._language = config.language
         self._initial_prompt = initial_prompt or None
 
-    def transcribe(self, audio: np.ndarray) -> str:
-        return " ".join(segment.text for segment in self.transcribe_segments(audio)).strip()
+    def transcribe(self, audio: np.ndarray, *, initial_prompt: str | None = None) -> str:
+        return " ".join(
+            segment.text
+            for segment in self.transcribe_segments(
+                audio,
+                initial_prompt=initial_prompt,
+            )
+        ).strip()
 
-    def transcribe_segments(self, audio: np.ndarray) -> list[TranscriptionSegment]:
+    def transcribe_segments(
+        self,
+        audio: np.ndarray,
+        *,
+        initial_prompt: str | None = None,
+    ) -> list[TranscriptionSegment]:
+        prompt = initial_prompt if initial_prompt is not None else self._initial_prompt
         try:
             segments, _info = self._model.transcribe(
                 audio,
                 language=self._language,
                 vad_filter=True,
                 beam_size=1,
-                initial_prompt=self._initial_prompt,
+                initial_prompt=prompt,
             )
             results = [
                 TranscriptionSegment(

--- a/src/meeting_minutes/transcript_filter.py
+++ b/src/meeting_minutes/transcript_filter.py
@@ -34,9 +34,9 @@ class TranscriptFilter:
         self._config = config
         self.stats = stats or TranscriptRejectionStats()
         self._false_positives = {
-            normalize_transcript_text(text).casefold()
+            normalized_text.casefold()
             for text in config.canned_false_positives
-            if normalize_transcript_text(text)
+            if (normalized_text := normalize_transcript_text(text))
         }
 
     def should_keep(self, text: str) -> bool:

--- a/src/meeting_minutes/transcript_filter.py
+++ b/src/meeting_minutes/transcript_filter.py
@@ -1,0 +1,87 @@
+from collections import Counter
+from dataclasses import dataclass, field
+
+from meeting_minutes.config import TranscriptFilterConfig
+
+
+def normalize_transcript_text(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass
+class TranscriptFilterStats:
+    total: int = 0
+    by_reason: Counter[str] = field(default_factory=Counter)
+
+    def record(self, reason: str) -> None:
+        self.total += 1
+        self.by_reason[reason] += 1
+
+    def as_dict(self) -> dict[str, int | dict[str, int]]:
+        return {
+            "total": self.total,
+            "by_reason": dict(sorted(self.by_reason.items())),
+        }
+
+
+class TranscriptFilter:
+    def __init__(
+        self,
+        config: TranscriptFilterConfig,
+        *,
+        stats: TranscriptFilterStats | None = None,
+    ) -> None:
+        self._config = config
+        self.stats = stats or TranscriptFilterStats()
+        self._false_positives = {
+            normalize_transcript_text(text).casefold()
+            for text in config.canned_false_positives
+            if normalize_transcript_text(text)
+        }
+
+    def should_keep(self, text: str) -> bool:
+        normalized = normalize_transcript_text(text)
+        reason = self._rejection_reason(normalized)
+        if reason is None:
+            return True
+        self.stats.record(reason)
+        return False
+
+    def _rejection_reason(self, text: str) -> str | None:
+        if not self._config.enabled:
+            return None
+        if not text:
+            return "blank"
+        if text.casefold() in self._false_positives:
+            return "canned_false_positive"
+        if len(text) < self._config.min_text_chars:
+            return "too_short"
+        if _is_repeated_short_pattern(
+            text,
+            max_pattern_chars=self._config.max_repeat_pattern_chars,
+            min_repeats=self._config.min_repeat_count,
+        ):
+            return "repeated_pattern"
+        return None
+
+
+def _is_repeated_short_pattern(
+    text: str,
+    *,
+    max_pattern_chars: int,
+    min_repeats: int,
+) -> bool:
+    compact = "".join(text.split())
+    if not compact or min_repeats < 2:
+        return False
+    max_pattern = min(max_pattern_chars, len(compact) // min_repeats)
+    for pattern_length in range(1, max_pattern + 1):
+        if len(compact) % pattern_length != 0:
+            continue
+        repeats = len(compact) // pattern_length
+        if repeats < min_repeats:
+            continue
+        pattern = compact[:pattern_length]
+        if pattern * repeats == compact:
+            return True
+    return False

--- a/src/meeting_minutes/transcript_filter.py
+++ b/src/meeting_minutes/transcript_filter.py
@@ -9,7 +9,7 @@ def normalize_transcript_text(text: str) -> str:
 
 
 @dataclass
-class TranscriptFilterStats:
+class TranscriptRejectionStats:
     total: int = 0
     by_reason: Counter[str] = field(default_factory=Counter)
 
@@ -29,10 +29,10 @@ class TranscriptFilter:
         self,
         config: TranscriptFilterConfig,
         *,
-        stats: TranscriptFilterStats | None = None,
+        stats: TranscriptRejectionStats | None = None,
     ) -> None:
         self._config = config
-        self.stats = stats or TranscriptFilterStats()
+        self.stats = stats or TranscriptRejectionStats()
         self._false_positives = {
             normalize_transcript_text(text).casefold()
             for text in config.canned_false_positives

--- a/src/meeting_minutes/vocabulary.py
+++ b/src/meeting_minutes/vocabulary.py
@@ -67,6 +67,77 @@ def build_initial_prompt(vocab: Vocabulary, *, max_chars: int) -> str | None:
     return ""
 
 
+def build_contextual_initial_prompt(
+    vocab: Vocabulary,
+    *,
+    recent_context: str,
+    max_chars: int,
+    recent_context_chars: int,
+) -> str | None:
+    static_prompt = build_initial_prompt(vocab, max_chars=max_chars) or ""
+    if max_chars <= 0:
+        return None
+    recent = _truncate_recent_context(recent_context, max_chars=recent_context_chars)
+    if not recent:
+        return static_prompt or None
+
+    if not static_prompt:
+        return _build_recent_context_section(recent, max_chars=max_chars)
+
+    remaining = max_chars - len(static_prompt) - 1
+    if remaining <= 0:
+        return static_prompt
+    context_section = _build_recent_context_section(recent, max_chars=remaining)
+    if not context_section:
+        return static_prompt
+    return f"{static_prompt} {context_section}"
+
+
+class RecentTranscriptContext:
+    def __init__(self, *, max_chars: int) -> None:
+        self._max_chars = max_chars
+        self._text = ""
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def append(self, text: str) -> None:
+        if self._max_chars <= 0:
+            return
+        normalized = " ".join(text.split())
+        if not normalized:
+            return
+        self._text = _truncate_recent_context(
+            f"{self._text} {normalized}".strip(),
+            max_chars=self._max_chars,
+        )
+
+
+def _truncate_recent_context(text: str, *, max_chars: int) -> str:
+    normalized = " ".join(text.split())
+    if max_chars <= 0 or not normalized:
+        return ""
+    if len(normalized) <= max_chars:
+        return normalized
+    candidate = normalized[-max_chars:]
+    first_space = candidate.find(" ")
+    if first_space >= 0:
+        return candidate[first_space + 1 :]
+    return candidate
+
+
+def _build_recent_context_section(recent_context: str, *, max_chars: int) -> str:
+    label = "直近の文字起こし: "
+    if max_chars <= len(label):
+        return ""
+    recent = _truncate_recent_context(
+        recent_context,
+        max_chars=max_chars - len(label),
+    )
+    return f"{label}{recent}" if recent else ""
+
+
 def build_summary_section(vocab: Vocabulary, *, max_chars: int = 0) -> str:
     """要約プロンプトに差し込む参加者・用語セクションを生成する。
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from meeting_minutes.config import VadConfig, apply_overrides, load_config
+from meeting_minutes.config import PreprocessingConfig, VadConfig, apply_overrides, load_config
 
 
 def test_load_config_from_toml(tmp_path: Path) -> None:
@@ -23,6 +23,9 @@ ollama_model = "gemma4:latest"
     config = load_config(config_file)
 
     assert config.audio.device == "BlackHole 2ch"
+    assert not config.preprocessing.enabled
+    assert config.transcript_filter.enabled
+    assert not config.vocabulary.dynamic_context_enabled
     assert config.audio.chunk_seconds == 5
     assert not config.audio.abort_on_overflow
     assert config.summarization.ollama_model == "gemma4:latest"
@@ -50,6 +53,9 @@ def test_apply_overrides_updates_multiple_sections() -> None:
             "summarization.ollama_model": "gemma4:e4b",
             "output.save_transcript": False,
             "chunking.chunk_size": 1000,
+            "preprocessing.enabled": True,
+            "transcript_filter.min_text_chars": 2,
+            "vocabulary.dynamic_context_enabled": True,
         },
     )
 
@@ -58,6 +64,14 @@ def test_apply_overrides_updates_multiple_sections() -> None:
     assert config.summarization.ollama_model == "gemma4:e4b"
     assert not config.output.save_transcript
     assert config.chunking.chunk_size == 1000
+    assert config.preprocessing.enabled
+    assert config.transcript_filter.min_text_chars == 2
+    assert config.vocabulary.dynamic_context_enabled
+
+
+def test_preprocessing_config_rejects_invalid_peak() -> None:
+    with pytest.raises(ValueError, match="target_peak"):
+        PreprocessingConfig(target_peak=2.0)
 
 
 def test_apply_overrides_raises_for_unknown_section() -> None:

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from meeting_minutes.audio_stream import AudioOverflowError
-from meeting_minutes.config import AppConfig, AudioConfig, OutputConfig
+from meeting_minutes.config import AppConfig, AudioConfig, OutputConfig, PreprocessingConfig
 from meeting_minutes.devices import InputDevice
 from meeting_minutes.live import DraftScheduler, _segment_elapsed_range, run_live
 from meeting_minutes.transcribe import TranscriptionSegment
@@ -37,7 +37,12 @@ def fake_transcriber(monkeypatch: pytest.MonkeyPatch) -> None:
         def __init__(self, _config: object, *, initial_prompt: object = None) -> None:
             pass
 
-        def transcribe_segments(self, _chunk: np.ndarray) -> list[TranscriptionSegment]:
+        def transcribe_segments(
+            self,
+            _chunk: np.ndarray,
+            *,
+            initial_prompt: str | None = None,
+        ) -> list[TranscriptionSegment]:
             return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
 
     monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
@@ -109,6 +114,44 @@ def test_run_live_writes_audio_and_transcript(
     audio_path = next(tmp_path.glob("*/audio_live.wav"))
     assert "[00:00:00 - 00:00:01] hello" in transcript
     assert audio_path.stat().st_size > 44
+
+
+def test_run_live_applies_preprocessing_before_transcription(
+    tmp_path: Path,
+    input_device: InputDevice,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_peaks: list[float] = []
+
+    def fake_audio_chunks(**_kwargs: object) -> Iterator[np.ndarray]:
+        yield np.full(16000, 0.1, dtype=np.float32)
+
+    class FakeTranscriber:
+        def __init__(self, _config: object, *, initial_prompt: object = None) -> None:
+            pass
+
+        def transcribe_segments(
+            self,
+            chunk: np.ndarray,
+            *,
+            initial_prompt: str | None = None,
+        ) -> list[TranscriptionSegment]:
+            captured_peaks.append(float(np.max(np.abs(chunk))))
+            return [TranscriptionSegment(start=0.1, end=0.9, text="hello")]
+
+    monkeypatch.setattr("meeting_minutes.live.resolve_input_device", lambda *_args: input_device)
+    monkeypatch.setattr("meeting_minutes.live.audio_chunks", fake_audio_chunks)
+    monkeypatch.setattr("meeting_minutes.live.WhisperTranscriber", FakeTranscriber)
+
+    config = AppConfig(
+        audio=AudioConfig(chunk_seconds=1),
+        output=OutputConfig(base_dir=tmp_path),
+        preprocessing=PreprocessingConfig(enabled=True, target_peak=0.5),
+    )
+
+    run_live(config)
+
+    assert captured_peaks == [pytest.approx(0.5)]
 
 
 def test_run_live_continues_when_audio_writer_cannot_open(

--- a/tests/test_live_transcription.py
+++ b/tests/test_live_transcription.py
@@ -1,15 +1,46 @@
 import numpy as np
 
-from meeting_minutes.config import VadConfig
+from meeting_minutes.config import TranscriptFilterConfig, VadConfig
 from meeting_minutes.dedupe import TranscriptDedupe
 from meeting_minutes.live_transcription import SpeechTranscriptionRunner
 from meeting_minutes.transcribe import TranscriptionSegment
+from meeting_minutes.transcript_filter import TranscriptFilter
 from meeting_minutes.vad import SpeechSegmenter
 
 
 class FakeTranscriber:
-    def transcribe_segments(self, _audio: np.ndarray) -> list[TranscriptionSegment]:
+    def transcribe_segments(
+        self,
+        _audio: np.ndarray,
+        *,
+        initial_prompt: str | None = None,
+    ) -> list[TranscriptionSegment]:
         return [TranscriptionSegment(start=0, end=0.2, text="hello")]
+
+
+class PromptRecordingTranscriber:
+    def __init__(self) -> None:
+        self.prompts: list[str | None] = []
+
+    def transcribe_segments(
+        self,
+        _audio: np.ndarray,
+        *,
+        initial_prompt: str | None = None,
+    ) -> list[TranscriptionSegment]:
+        self.prompts.append(initial_prompt)
+        return [TranscriptionSegment(start=0, end=0.2, text="hello")]
+
+
+class FakePromptContext:
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def build(self) -> str | None:
+        return "context"
+
+    def append(self, text: str) -> None:
+        self.texts.append(text)
 
 
 class SegmentCollector:
@@ -39,6 +70,7 @@ def test_speech_transcription_runner_writes_detected_speech() -> None:
         ),
         transcriber=FakeTranscriber(),
         dedupe=TranscriptDedupe(),
+        transcript_filter=TranscriptFilter(TranscriptFilterConfig()),
         segment_writer=collector,
     )
 
@@ -61,6 +93,7 @@ def test_speech_transcription_runner_flushes_pending_speech() -> None:
         ),
         transcriber=FakeTranscriber(),
         dedupe=TranscriptDedupe(),
+        transcript_filter=TranscriptFilter(TranscriptFilterConfig()),
         segment_writer=collector,
     )
 
@@ -75,9 +108,45 @@ def test_speech_transcription_runner_passthrough_when_vad_is_disabled() -> None:
         speech_segmenter=SpeechSegmenter(VadConfig(enabled=False), sample_rate=10),
         transcriber=FakeTranscriber(),
         dedupe=TranscriptDedupe(),
+        transcript_filter=TranscriptFilter(TranscriptFilterConfig()),
         segment_writer=collector,
     )
 
     assert runner.process(np.full(2, 0.1, dtype=np.float32))
     assert len(collector.calls) == 1
     assert collector.calls[0][0] == 0
+
+
+def test_speech_transcription_runner_filters_noise() -> None:
+    collector = SegmentCollector()
+    runner = SpeechTranscriptionRunner(
+        speech_segmenter=SpeechSegmenter(VadConfig(enabled=False), sample_rate=10),
+        transcriber=FakeTranscriber(),
+        dedupe=TranscriptDedupe(),
+        transcript_filter=TranscriptFilter(
+            TranscriptFilterConfig(canned_false_positives=["hello"]),
+        ),
+        segment_writer=collector,
+    )
+
+    assert not runner.process(np.full(2, 0.1, dtype=np.float32))
+    assert collector.calls == []
+
+
+def test_speech_transcription_runner_uses_and_updates_prompt_context() -> None:
+    collector = SegmentCollector()
+    transcriber = PromptRecordingTranscriber()
+    prompt_context = FakePromptContext()
+    runner = SpeechTranscriptionRunner(
+        speech_segmenter=SpeechSegmenter(VadConfig(enabled=False), sample_rate=10),
+        transcriber=transcriber,
+        dedupe=TranscriptDedupe(),
+        transcript_filter=TranscriptFilter(TranscriptFilterConfig()),
+        segment_writer=collector,
+        prompt_context=prompt_context,
+    )
+
+    assert runner.process(np.full(2, 0.1, dtype=np.float32))
+
+    assert transcriber.prompts == ["context"]
+    assert prompt_context.texts == ["hello"]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -28,7 +28,7 @@ def test_write_metadata_serializes_datetime_and_path(tmp_path: Path) -> None:
         transcript_path=transcript_path,
         audio_path=audio_path,
         errors=[],
-        transcript_filter={"total": 2, "by_reason": {"duplicate": 1, "repeated_pattern": 1}},
+        transcript_rejections={"total": 2, "by_reason": {"duplicate": 1, "repeated_pattern": 1}},
     )
     output = tmp_path / "metadata.json"
 
@@ -39,7 +39,7 @@ def test_write_metadata_serializes_datetime_and_path(tmp_path: Path) -> None:
     assert data["ended_at"] == "2026-04-28T10:00:08"
     assert data["transcript_path"] == str(transcript_path)
     assert data["audio_path"] == str(audio_path)
-    assert data["transcript_filter"] == {
+    assert data["transcript_rejections"] == {
         "total": 2,
         "by_reason": {"duplicate": 1, "repeated_pattern": 1},
     }

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -28,6 +28,7 @@ def test_write_metadata_serializes_datetime_and_path(tmp_path: Path) -> None:
         transcript_path=transcript_path,
         audio_path=audio_path,
         errors=[],
+        transcript_filter={"total": 2, "by_reason": {"duplicate": 1, "repeated_pattern": 1}},
     )
     output = tmp_path / "metadata.json"
 
@@ -38,4 +39,8 @@ def test_write_metadata_serializes_datetime_and_path(tmp_path: Path) -> None:
     assert data["ended_at"] == "2026-04-28T10:00:08"
     assert data["transcript_path"] == str(transcript_path)
     assert data["audio_path"] == str(audio_path)
+    assert data["transcript_filter"] == {
+        "total": 2,
+        "by_reason": {"duplicate": 1, "repeated_pattern": 1},
+    }
     assert data["processing_seconds"] == pytest.approx(8.530865)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from meeting_minutes.config import PreprocessingConfig
 from meeting_minutes.preprocess import AudioPreprocessor
@@ -20,7 +21,7 @@ def test_preprocessor_normalizes_peak_upward() -> None:
     ).process(audio)
 
     assert processed.dtype == np.float32
-    assert np.max(np.abs(processed)) == np.float32(0.8)
+    assert float(np.max(np.abs(processed))) == pytest.approx(0.8)
 
 
 def test_preprocessor_normalizes_peak_downward() -> None:
@@ -31,7 +32,7 @@ def test_preprocessor_normalizes_peak_downward() -> None:
     ).process(audio)
 
     assert processed.dtype == np.float32
-    assert np.max(np.abs(processed)) == np.float32(0.8)
+    assert float(np.max(np.abs(processed))) == pytest.approx(0.8)
 
 
 def test_preprocessor_does_not_amplify_silence() -> None:

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from meeting_minutes.config import PreprocessingConfig
+from meeting_minutes.preprocess import AudioPreprocessor
+
+
+def test_preprocessor_is_noop_when_disabled() -> None:
+    audio = np.array([0.1, -0.2], dtype=np.float32)
+
+    processed = AudioPreprocessor(PreprocessingConfig(enabled=False)).process(audio)
+
+    assert np.array_equal(processed, audio)
+
+
+def test_preprocessor_normalizes_peak_upward() -> None:
+    audio = np.array([0.1, -0.2], dtype=np.float32)
+
+    processed = AudioPreprocessor(
+        PreprocessingConfig(enabled=True, target_peak=0.8),
+    ).process(audio)
+
+    assert np.max(np.abs(processed)) == np.float32(0.8)
+
+
+def test_preprocessor_normalizes_peak_downward() -> None:
+    audio = np.array([0.5, -1.0], dtype=np.float32)
+
+    processed = AudioPreprocessor(
+        PreprocessingConfig(enabled=True, target_peak=0.8),
+    ).process(audio)
+
+    assert np.max(np.abs(processed)) == np.float32(0.8)
+
+
+def test_preprocessor_does_not_amplify_silence() -> None:
+    audio = np.zeros(4, dtype=np.float32)
+
+    processed = AudioPreprocessor(PreprocessingConfig(enabled=True)).process(audio)
+
+    assert np.array_equal(processed, audio)
+
+
+def test_preprocessor_applies_noise_gate() -> None:
+    audio = np.array([0.001, 0.01, -0.002], dtype=np.float32)
+
+    processed = AudioPreprocessor(
+        PreprocessingConfig(
+            enabled=True,
+            normalize_peak=False,
+            noise_gate_enabled=True,
+            noise_gate_threshold=0.003,
+        ),
+    ).process(audio)
+
+    assert np.array_equal(processed, np.array([0.0, 0.01, 0.0], dtype=np.float32))

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -19,6 +19,7 @@ def test_preprocessor_normalizes_peak_upward() -> None:
         PreprocessingConfig(enabled=True, target_peak=0.8),
     ).process(audio)
 
+    assert processed.dtype == np.float32
     assert np.max(np.abs(processed)) == np.float32(0.8)
 
 
@@ -29,6 +30,7 @@ def test_preprocessor_normalizes_peak_downward() -> None:
         PreprocessingConfig(enabled=True, target_peak=0.8),
     ).process(audio)
 
+    assert processed.dtype == np.float32
     assert np.max(np.abs(processed)) == np.float32(0.8)
 
 
@@ -52,4 +54,5 @@ def test_preprocessor_applies_noise_gate() -> None:
         ),
     ).process(audio)
 
+    assert processed.dtype == np.float32
     assert np.array_equal(processed, np.array([0.0, 0.01, 0.0], dtype=np.float32))

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -68,3 +68,18 @@ def test_transcribe_segments_passes_initial_prompt() -> None:
     transcriber.transcribe_segments(np.zeros(16000, dtype=np.float32))
 
     assert fake_model.last_kwargs["initial_prompt"] == "参加者: 田中"
+
+
+def test_transcribe_segments_accepts_per_call_initial_prompt() -> None:
+    fake_model = FakeWhisperModel()
+    transcriber = WhisperTranscriber.__new__(WhisperTranscriber)
+    transcriber._model = fake_model
+    transcriber._language = "ja"
+    transcriber._initial_prompt = "参加者: 田中"
+
+    transcriber.transcribe_segments(
+        np.zeros(16000, dtype=np.float32),
+        initial_prompt="参加者: 鈴木",
+    )
+
+    assert fake_model.last_kwargs["initial_prompt"] == "参加者: 鈴木"

--- a/tests/test_transcript_filter.py
+++ b/tests/test_transcript_filter.py
@@ -1,9 +1,9 @@
 from meeting_minutes.config import TranscriptFilterConfig
-from meeting_minutes.transcript_filter import TranscriptFilter, TranscriptFilterStats
+from meeting_minutes.transcript_filter import TranscriptFilter, TranscriptRejectionStats
 
 
 def test_transcript_filter_skips_canned_false_positive() -> None:
-    stats = TranscriptFilterStats()
+    stats = TranscriptRejectionStats()
     transcript_filter = TranscriptFilter(
         TranscriptFilterConfig(canned_false_positives=["Thank you."]),
         stats=stats,

--- a/tests/test_transcript_filter.py
+++ b/tests/test_transcript_filter.py
@@ -1,0 +1,25 @@
+from meeting_minutes.config import TranscriptFilterConfig
+from meeting_minutes.transcript_filter import TranscriptFilter, TranscriptFilterStats
+
+
+def test_transcript_filter_skips_canned_false_positive() -> None:
+    stats = TranscriptFilterStats()
+    transcript_filter = TranscriptFilter(
+        TranscriptFilterConfig(canned_false_positives=["Thank you."]),
+        stats=stats,
+    )
+
+    assert not transcript_filter.should_keep(" Thank   you. ")
+    assert stats.as_dict() == {"total": 1, "by_reason": {"canned_false_positive": 1}}
+
+
+def test_transcript_filter_skips_repeated_short_pattern() -> None:
+    transcript_filter = TranscriptFilter(TranscriptFilterConfig())
+
+    assert not transcript_filter.should_keep("はいはいはいはい")
+
+
+def test_transcript_filter_keeps_normal_text() -> None:
+    transcript_filter = TranscriptFilter(TranscriptFilterConfig())
+
+    assert transcript_filter.should_keep("今日は仕様を確認します")

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 from meeting_minutes.config import VocabularyConfig
 from meeting_minutes.vocabulary import (
+    RecentTranscriptContext,
     Vocabulary,
+    build_contextual_initial_prompt,
     build_initial_prompt,
     build_summary_section,
     load_vocabulary,
@@ -79,6 +81,39 @@ def test_build_initial_prompt_returns_none_when_max_chars_zero() -> None:
     vocab = Vocabulary(participants=["田中"])
 
     assert build_initial_prompt(vocab, max_chars=0) is None
+
+
+def test_build_contextual_initial_prompt_combines_static_and_recent_context() -> None:
+    vocab = Vocabulary(participants=["田中"], glossary=["ABC"])
+
+    prompt = build_contextual_initial_prompt(
+        vocab,
+        recent_context="今日は ABC の設計を確認します",
+        max_chars=80,
+        recent_context_chars=20,
+    )
+
+    assert prompt == "参加者: 田中 用語: ABC 直近の文字起こし: 今日は ABC の設計を確認します"
+
+
+def test_build_contextual_initial_prompt_preserves_recent_context_label_when_truncated() -> None:
+    prompt = build_contextual_initial_prompt(
+        Vocabulary(),
+        recent_context="first second third fourth",
+        max_chars=20,
+        recent_context_chars=100,
+    )
+
+    assert prompt == "直近の文字起こし: fourth"
+
+
+def test_recent_transcript_context_keeps_recent_tail() -> None:
+    context = RecentTranscriptContext(max_chars=10)
+
+    context.append("first phrase")
+    context.append("second phrase")
+
+    assert context.text == "phrase"
 
 
 def test_build_summary_section_returns_empty_for_empty_vocab() -> None:


### PR DESCRIPTION
## Summary

- Add optional audio preprocessing with peak normalization and a simple noise gate before VAD/transcription while keeping saved WAV audio raw.
- Add post-transcription rejection handling for canned false positives, too-short text, repeated short patterns, and dedupe skips, with structured metadata counters under transcript_rejections.
- Add optional dynamic Whisper initial_prompt context from accepted recent transcript text, disabled by default in example/config defaults.
- Include the previously missed __version__ = 0.2.0 release metadata update.

Closes #8 
Closes #9 
Closes #10


## Notes

- config.example.toml keeps dynamic_context_enabled = false by default.
- Local config.toml was updated separately for your environment with dynamic_context_enabled = true, but it is not tracked and is not part of this PR.

## Validation

- uv run ruff check src tests
- uv run mypy src
- uv run pytest (70 passed)
- uv run ruff format src tests