### PR TITLE
docs: errors.py の docstring を日本語に統一

### DIFF
--- a/src/meeting_minutes/errors.py
+++ b/src/meeting_minutes/errors.py
@@ -1,17 +1,17 @@
-"""Domain-specific exceptions with user-facing messages."""
+"""ユーザー向けメッセージを持つドメイン固有の例外。"""
 
 
 class MeetingMinutesError(Exception):
-    """Base exception for expected application failures."""
+    """想定内のアプリケーション障害の基底例外。"""
 
 
 class DeviceNotFoundError(MeetingMinutesError):
-    """Raised when a requested audio input device cannot be resolved."""
+    """要求されたオーディオ入力デバイスを解決できない場合に送出される。"""
 
 
 class OllamaError(MeetingMinutesError):
-    """Raised when the local Ollama API cannot complete a generation."""
+    """ローカルの Ollama API が生成を完了できない場合に送出される。"""
 
 
 class TranscriptionError(MeetingMinutesError):
-    """Raised when Whisper setup or transcription fails."""
+    """Whisper のセットアップまたは文字起こしが失敗した場合に送出される。"""


### PR DESCRIPTION
## Summary

- `errors.py` 内の全 docstring を英語から日本語に統一
- summary-first（1行）スタイルを維持
- `uv run ruff check` pass 確認済み

Closes #26

## Test plan

- [x] `uv run ruff check src/meeting_minutes/errors.py` がパスすること
- [x] 全 docstring が日本語であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)