### PR TITLE
feat(config): config サブコマンドと daemon 起動ログで設定ファイル UX を改善する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,18 +26,19 @@ This is a **personal tool** the author runs locally on their own Mac. The repo i
 - `src/meeting_minutes/`: application code
 - `tests/`: pytest tests
 - `docs/`: user-facing documentation
-- `config.example.toml`: example runtime configuration
-- `output/`: generated runtime artifacts when `[output] base_dir = "output"` is set in config (e.g. `config.example.toml`); do not treat as source. Default for global install is `$XDG_DATA_HOME/meeting-minutes/output/`
+- `src/meeting_minutes/config/templates/config.example.toml`: example runtime configuration (packaged as wheel data so `meeting-minutes config init` can write it out after `uv tool install .`)
+- `output/`: generated runtime artifacts when `[output] base_dir = "output"` is set in config; do not treat as source. Default for global install is `$XDG_DATA_HOME/meeting-minutes/output/`
 
 Important modules:
 
-- `cli.py`: Typer command definitions and CLI override wiring. **As command groups grow, extract them into a subpackage (e.g. `daemon/cli.py` for `daemon` subcommands) instead of accumulating helper functions directly in `cli.py`.** Existing top-level commands such as `devices`, `check`, `live`, `draft`, `finalize`, and `clean` remain in `cli.py` for now; refactor them out the same way once their helpers start to grow.
+- `cli.py`: Typer command definitions and CLI override wiring. **As command groups grow, extract them into a subpackage (e.g. `daemon/cli.py` for `daemon` subcommands, `config/cli.py` for `config` subcommands) instead of accumulating helper functions directly in `cli.py`.** Existing top-level commands such as `devices`, `check`, `live`, `draft`, `finalize`, and `clean` remain in `cli.py` for now; refactor them out the same way once their helpers start to grow.
 - `live.py`: realtime recording/transcription loop
 - `audio_stream.py`: input stream buffering
 - `transcribe.py`: faster-whisper wrapper
 - `summarize.py`: chunking and minutes generation workflow
 - `ollama_client.py`: Ollama HTTP client
-- `config.py`: Pydantic settings and overrides
+- `config/__init__.py`: Pydantic settings, overrides, and `resolve_config_source` / `read_template_config_text` helpers
+- `config/cli.py`: `meeting-minutes config` subcommands (init / path / show / edit) and `describe_config_source` shared with `daemon serve` startup logging
 - `metadata.py`: session metadata model and JSON output
 - `output.py`: transcript/session file helpers
 - `dedupe.py`: transcript duplicate suppression
@@ -76,6 +77,15 @@ uv run meeting-minutes daemon serve
 uv run meeting-minutes daemon start
 uv run meeting-minutes daemon status
 uv run meeting-minutes daemon stop
+```
+
+Config management:
+
+```bash
+uv run meeting-minutes config init        # write template to XDG default path
+uv run meeting-minutes config path        # show resolved config path
+uv run meeting-minutes config show        # dump resolved AppConfig as TOML
+uv run meeting-minutes config edit        # open in $EDITOR
 ```
 
 ## Python Style

--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ meeting-minutes --help
 | 設定ファイル | `~/.config/meeting-minutes/config.toml` | `$XDG_CONFIG_HOME` または `--config` |
 | 出力先 (`output.base_dir`) | `~/.local/share/meeting-minutes/output/` | `$XDG_DATA_HOME` または config の `[output] base_dir` |
 
-グローバルインストール時は、上書きしたいフィールドだけを書いた最小構成を置きます。
+グローバルインストール時は、雛形を生成してから必要なフィールドだけ残すのが楽です。
+
+```bash
+meeting-minutes config init   # ~/.config/meeting-minutes/config.toml を生成
+meeting-minutes config edit   # $EDITOR で開く（未設定時は macOS の open(1) が起動）
+meeting-minutes config path   # auto-discovery で参照されるパスを表示
+meeting-minutes config show   # 解決後の AppConfig を TOML/JSON で表示
+```
+
+最小構成を直接書く場合:
 
 ```bash
 mkdir -p ~/.config/meeting-minutes
@@ -52,14 +61,13 @@ device = "BlackHole 2ch"
 EOF
 ```
 
-利用可能な全フィールドのリファレンスは [config.example.toml](./config.example.toml) を参照してください。
-（`config.example.toml` を丸ごとコピーすると `[output] base_dir = "output"`
-を引き継いで XDG 既定が無効化される点に注意。）
+利用可能な全フィールドのリファレンスは [src/meeting_minutes/config/templates/config.example.toml](./src/meeting_minutes/config/templates/config.example.toml) を参照してください。
+（雛形を丸ごとコピーすると `[output] base_dir = "output"` を引き継いで XDG 既定が無効化される点に注意。）
 
 ## Commands
 
 グローバルインストール済みなら `uv run` を外して `meeting-minutes ...` で直接呼べます。
-以下の `<base_dir>` は `output.base_dir` の解決結果です（XDG 既定なら `~/.local/share/meeting-minutes/output`、`config.example.toml` を `--config` で渡したリポジトリ内ワークフローなら `<repo>/output`）。
+以下の `<base_dir>` は `output.base_dir` の解決結果です（XDG 既定なら `~/.local/share/meeting-minutes/output`、雛形を `--config src/meeting_minutes/config/templates/config.example.toml` で渡したリポジトリ内ワークフローなら `<repo>/output`）。
 
 ```bash
 uv run meeting-minutes check
@@ -89,7 +97,7 @@ uv run meeting-minutes daemon stop
 
 Raycast から daemon を制御したい場合は [scripts/raycast/README.md](./scripts/raycast/README.md) を参照してください。
 
-設定例は [config.example.toml](./config.example.toml) を参照してください。
+設定例は [src/meeting_minutes/config/templates/config.example.toml](./src/meeting_minutes/config/templates/config.example.toml) を参照してください。`meeting-minutes config init` で雛形を XDG 既定パスに書き出せます。
 
 詳しいCLI説明は [docs/cli.md](./docs/cli.md) を参照してください。
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ EOF
 ## Commands
 
 グローバルインストール済みなら `uv run` を外して `meeting-minutes ...` で直接呼べます。
-以下の `<base_dir>` は `output.base_dir` の解決結果です（XDG 既定なら `~/.local/share/meeting-minutes/output`、雛形を `--config src/meeting_minutes/config/templates/config.example.toml` で渡したリポジトリ内ワークフローなら `<repo>/output`）。
+以下の `<base_dir>` は `output.base_dir` の解決結果です（XDG 既定なら `~/.local/share/meeting-minutes/output`）。
+TOML 中の相対パスは設定ファイル自身のディレクトリ基準で anchor されるため、雛形を `--config` で直接渡すとパッケージ内 `src/meeting_minutes/config/templates/output/` に書き出されます。リポジトリ直下に出したい場合は `meeting-minutes config show > config.toml` などで一度コピーしてから `--config ./config.toml` を渡してください。
 
 ```bash
 uv run meeting-minutes check

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ EOF
 ```
 
 利用可能な全フィールドのリファレンスは [src/meeting_minutes/config/templates/config.example.toml](./src/meeting_minutes/config/templates/config.example.toml) を参照してください。
-（雛形を丸ごとコピーすると `[output] base_dir = "output"` を引き継いで XDG 既定が無効化される点に注意。）
+（雛形では `[output] base_dir` を含むパス系フィールドはコメントアウト済みで、デフォルトでは `$XDG_DATA_HOME/meeting-minutes/output/` が使われます。出力先を変えたい場合は雛形のコメントを外してください。）
 
 ## Commands
 
 グローバルインストール済みなら `uv run` を外して `meeting-minutes ...` で直接呼べます。
 以下の `<base_dir>` は `output.base_dir` の解決結果です（XDG 既定なら `~/.local/share/meeting-minutes/output`）。
-TOML 中の相対パスは設定ファイル自身のディレクトリ基準で anchor されるため、同梱の雛形を `--config` で直接渡すと出力もそのテンプレート自身のディレクトリ配下に書き込まれます。通常は `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` にコピーしてから編集してください。
+TOML 中の相対パスは設定ファイル自身のディレクトリ基準で anchor されるため、雛形のコメントを外して `base_dir = "output"` のような相対値を有効化した場合は、その設定ファイルが置かれているディレクトリの直下に書き出されます（例: 雛形を `--config` で直接渡すとテンプレート自身のディレクトリ配下に出ます）。出力場所を固定したい場合は絶対パスを書くか、`meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` にコピーしてから編集してください。
 
 ```bash
 uv run meeting-minutes check

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ EOF
 
 グローバルインストール済みなら `uv run` を外して `meeting-minutes ...` で直接呼べます。
 以下の `<base_dir>` は `output.base_dir` の解決結果です（XDG 既定なら `~/.local/share/meeting-minutes/output`）。
-TOML 中の相対パスは設定ファイル自身のディレクトリ基準で anchor されるため、雛形を `--config` で直接渡すとパッケージ内 `src/meeting_minutes/config/templates/output/` に書き出されます。リポジトリ直下に出したい場合は `meeting-minutes config show > config.toml` などで一度コピーしてから `--config ./config.toml` を渡してください。
+TOML 中の相対パスは設定ファイル自身のディレクトリ基準で anchor されるため、同梱の雛形を `--config` で直接渡すと出力もそのテンプレート自身のディレクトリ配下に書き込まれます。通常は `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` にコピーしてから編集してください。
 
 ```bash
 uv run meeting-minutes check

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,14 +31,18 @@ uv tool install .
 （未設定時は `~/.config/meeting-minutes/config.toml`）を自動で読み込みます。
 存在しなければ環境変数と組み込み既定値だけで動作します。
 
+雛形の生成・参照先の確認・編集は `config` サブコマンドで完結します。詳しくは [config](#config) を参照してください。
+
 `output.base_dir` の既定値は `$XDG_DATA_HOME/meeting-minutes/output/`
 （未設定時は `~/.local/share/meeting-minutes/output/`）です。
 
 明示的に上書きする方法:
 
 - 設定ファイルで指定: TOML 中の相対パスは設定ファイル自身のディレクトリ基準で解決されます。
-  例えばリポジトリ直下の `config.example.toml` に `base_dir = "output"` と書いて
-  `--config config.example.toml` で渡すと `<repo>/output/` に解決されます。
+  例えば雛形 `src/meeting_minutes/config/templates/config.example.toml` を `--config` で渡すと、
+  `base_dir = "output"` がそのディレクトリ基準で解決されます（リポジトリ内では
+  `src/meeting_minutes/config/templates/output/` になるので、通常は `meeting-minutes config init`
+  で `~/.config/meeting-minutes/config.toml` にコピーしてから編集します）。
 - 環境変数で指定: `MEETING_MINUTES_OUTPUT__BASE_DIR=path` を設定すると env 経路で
   上書きされ、相対パスは cwd 基準（=従来どおり）として扱われます。設定ファイル
   と異なり anchor されません。
@@ -52,7 +56,7 @@ uv tool install .
 4. 必要に応じて `clean` で文字起こしを整形する
 5. `draft` または `finalize` で議事録Markdownを生成する
 
-以下の例の `<base_dir>` は `output.base_dir` の解決結果（XDG 既定なら `~/.local/share/meeting-minutes/output`、`config.example.toml` を渡せば `<repo>/output`）。
+以下の例の `<base_dir>` は `output.base_dir` の解決結果（XDG 既定なら `~/.local/share/meeting-minutes/output`、雛形 `src/meeting_minutes/config/templates/config.example.toml` を `--config` で渡せばそのディレクトリ基準）。
 本ドキュメント内の他コマンド例も同様に読み替えてください。
 
 ```bash
@@ -86,7 +90,7 @@ uv run meeting-minutes check
 設定ファイルを指定する場合:
 
 ```bash
-uv run meeting-minutes check --config ./config.example.toml
+uv run meeting-minutes check --config ./src/meeting_minutes/config/templates/config.example.toml
 ```
 
 ## devices
@@ -208,7 +212,7 @@ uv run meeting-minutes daemon serve --port 9000
 設定ファイルを指定する場合:
 
 ```bash
-uv run meeting-minutes daemon serve --config ./config.example.toml
+uv run meeting-minutes daemon serve --config ./src/meeting_minutes/config/templates/config.example.toml
 ```
 
 | オプション | 既定値 | 説明 |
@@ -217,6 +221,20 @@ uv run meeting-minutes daemon serve --config ./config.example.toml
 | `--config` | なし | TOML設定ファイル |
 
 `127.0.0.1` のみに bind するため、外部ホストから TCP 接続することはできません。ブラウザ経由の CSRF は Origin ヘッダー検証（localhost / 127.0.0.1 以外を 403 で拒否）と CORS ポリシーの組み合わせで防いでいます。停止するには `Ctrl+C` を押します。
+
+起動直後に以下の INFO ログを出します。どの設定で動いているかを最初の数行で把握できます。
+
+```text
+INFO: config source: auto_discovered (/Users/<you>/.config/meeting-minutes/config.toml)
+INFO: output base_dir: /Users/<you>/.local/share/meeting-minutes/output
+INFO: listening on http://127.0.0.1:8765
+```
+
+`config source` は次のいずれかの形式で出ます。
+
+- `explicit (<path>)` — `--config` で明示指定された場合
+- `auto_discovered (<path>)` — XDG 既定パスを auto-discovery で拾った場合
+- `defaults (no config file at <would-be-path>)` — 設定ファイルが無く組み込み既定値だけで動いている場合
 
 #### API ドキュメント
 
@@ -345,7 +363,7 @@ uv run meeting-minutes draft <base_dir>/current/transcript_live.md --output <bas
 設定ファイルを使う場合:
 
 ```bash
-uv run meeting-minutes draft <base_dir>/current/transcript_live.md --config ./config.example.toml
+uv run meeting-minutes draft <base_dir>/current/transcript_live.md --config ./src/meeting_minutes/config/templates/config.example.toml
 ```
 
 ## finalize
@@ -376,12 +394,63 @@ uv run meeting-minutes finalize \
 uv run meeting-minutes finalize <base_dir>/current/transcript_live.md --output <base_dir>/current/minutes.md
 ```
 
+## config
+
+設定ファイルの初期化・参照先確認・編集をまとめた管理コマンドです。
+
+### config init
+
+XDG 既定パス (`~/.config/meeting-minutes/config.toml`) に同梱の雛形を書き出します。
+既存ファイルがある場合は `--force` を付けないと上書きしません。
+
+```bash
+meeting-minutes config init
+meeting-minutes config init --force   # 既存を上書きする
+```
+
+### config path
+
+現在 `--config` 未指定時に参照される config パスを表示します。
+
+```bash
+meeting-minutes config path
+# 例: source: auto_discovered
+#     path:   /Users/<you>/.config/meeting-minutes/config.toml
+```
+
+`--config` を指定するとそのパスを `explicit` 表示で確認できます。設定ファイルが
+未作成のときは `defaults (no config file)` と `would-be path:`（`config init` が
+作成するパス）を出します。
+
+### config show
+
+env / TOML / 既定値を解決した後の `AppConfig` を出力します。
+
+```bash
+meeting-minutes config show               # TOML 形式（既定）
+meeting-minutes config show --format json # JSON 形式
+meeting-minutes config show --config ./foo.toml
+```
+
+`AppConfig` の None フィールド（`audio.device` 未指定など）は TOML が null を
+表現できないため出力から省かれます。
+
+### config edit
+
+auto-discovery で解決された config を `$EDITOR` で開きます。`$EDITOR` 未設定時は
+macOS の `open(1)` でデフォルトアプリに渡します。設定ファイルが未作成のときは
+先に `config init` するよう案内します。
+
+```bash
+meeting-minutes config edit
+```
+
 ## 設定ファイル
 
 TOML形式の設定ファイルを指定できます。
 
 ```bash
-uv run meeting-minutes live --config ./config.example.toml
+uv run meeting-minutes live --config ./src/meeting_minutes/config/templates/config.example.toml
 ```
 
 CLIオプションは設定ファイルより優先されます。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,10 +39,10 @@ uv tool install .
 明示的に上書きする方法:
 
 - 設定ファイルで指定: TOML 中の相対パスは設定ファイル自身のディレクトリ基準で解決されます。
-  例えば雛形 `src/meeting_minutes/config/templates/config.example.toml` を `--config` で渡すと、
-  `base_dir = "output"` がそのディレクトリ基準で解決されます（リポジトリ内では
-  `src/meeting_minutes/config/templates/output/` になるので、通常は `meeting-minutes config init`
-  で `~/.config/meeting-minutes/config.toml` にコピーしてから編集します）。
+  例えば雛形をそのまま `--config` で渡すと `base_dir = "output"` が雛形のあるパッケージ内
+  ディレクトリ (`src/meeting_minutes/config/templates/output/`) に解決されてしまうため、
+  通常は `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` に
+  コピーしてから編集してください。
 - 環境変数で指定: `MEETING_MINUTES_OUTPUT__BASE_DIR=path` を設定すると env 経路で
   上書きされ、相対パスは cwd 基準（=従来どおり）として扱われます。設定ファイル
   と異なり anchor されません。
@@ -56,7 +56,7 @@ uv tool install .
 4. 必要に応じて `clean` で文字起こしを整形する
 5. `draft` または `finalize` で議事録Markdownを生成する
 
-以下の例の `<base_dir>` は `output.base_dir` の解決結果（XDG 既定なら `~/.local/share/meeting-minutes/output`、雛形 `src/meeting_minutes/config/templates/config.example.toml` を `--config` で渡せばそのディレクトリ基準）。
+以下の例の `<base_dir>` は `output.base_dir` の解決結果（XDG 既定なら `~/.local/share/meeting-minutes/output`、`config.toml` で `[output] base_dir` を指定した場合はそのパス）。
 本ドキュメント内の他コマンド例も同様に読み替えてください。
 
 ```bash
@@ -90,7 +90,7 @@ uv run meeting-minutes check
 設定ファイルを指定する場合:
 
 ```bash
-uv run meeting-minutes check --config ./src/meeting_minutes/config/templates/config.example.toml
+uv run meeting-minutes check --config ~/.config/meeting-minutes/config.toml
 ```
 
 ## devices
@@ -212,7 +212,7 @@ uv run meeting-minutes daemon serve --port 9000
 設定ファイルを指定する場合:
 
 ```bash
-uv run meeting-minutes daemon serve --config ./src/meeting_minutes/config/templates/config.example.toml
+uv run meeting-minutes daemon serve --config ~/.config/meeting-minutes/config.toml
 ```
 
 | オプション | 既定値 | 説明 |
@@ -363,7 +363,7 @@ uv run meeting-minutes draft <base_dir>/current/transcript_live.md --output <bas
 設定ファイルを使う場合:
 
 ```bash
-uv run meeting-minutes draft <base_dir>/current/transcript_live.md --config ./src/meeting_minutes/config/templates/config.example.toml
+uv run meeting-minutes draft <base_dir>/current/transcript_live.md --config ~/.config/meeting-minutes/config.toml
 ```
 
 ## finalize
@@ -450,7 +450,7 @@ meeting-minutes config edit
 TOML形式の設定ファイルを指定できます。
 
 ```bash
-uv run meeting-minutes live --config ./src/meeting_minutes/config/templates/config.example.toml
+uv run meeting-minutes live --config ~/.config/meeting-minutes/config.toml
 ```
 
 CLIオプションは設定ファイルより優先されます。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,10 +39,12 @@ uv tool install .
 明示的に上書きする方法:
 
 - 設定ファイルで指定: TOML 中の相対パスは設定ファイル自身のディレクトリ基準で解決されます。
-  例えば雛形をそのまま `--config` で渡すと `base_dir = "output"` が雛形のあるパッケージ内
-  ディレクトリ (`src/meeting_minutes/config/templates/output/`) に解決されてしまうため、
-  通常は `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` に
-  コピーしてから編集してください。
+  同梱の雛形を `--config` でそのまま渡すと、出力もテンプレート自身のディレクトリ配下に
+  書き込まれます（リポジトリ内ならソースツリー、`uv tool install .` 後ならインストール
+  された wheel の site-packages 配下）。通常は `meeting-minutes config init` で
+  `~/.config/meeting-minutes/config.toml` にコピーしてから編集してください。
+  なお `config init` で書き出される雛形は `[output] base_dir` をコメントアウトしているため、
+  そのまま使えば `$XDG_DATA_HOME/meeting-minutes/output/` に出力されます。
 - 環境変数で指定: `MEETING_MINUTES_OUTPUT__BASE_DIR=path` を設定すると env 経路で
   上書きされ、相対パスは cwd 基準（=従来どおり）として扱われます。設定ファイル
   と異なり anchor されません。
@@ -222,12 +224,11 @@ uv run meeting-minutes daemon serve --config ~/.config/meeting-minutes/config.to
 
 `127.0.0.1` のみに bind するため、外部ホストから TCP 接続することはできません。ブラウザ経由の CSRF は Origin ヘッダー検証（localhost / 127.0.0.1 以外を 403 で拒否）と CORS ポリシーの組み合わせで防いでいます。停止するには `Ctrl+C` を押します。
 
-起動直後に以下の INFO ログを出します。どの設定で動いているかを最初の数行で把握できます。
+起動直後に以下の INFO ログを出します。どの設定で動いているかを最初の数行で把握できます（待ち受けアドレスは uvicorn 自身が出す `Uvicorn running on http://...` で確認できます）。
 
 ```text
 INFO: config source: auto_discovered (/Users/<you>/.config/meeting-minutes/config.toml)
 INFO: output base_dir: /Users/<you>/.local/share/meeting-minutes/output
-INFO: listening on http://127.0.0.1:8765
 ```
 
 `config source` は次のいずれかの形式で出ます。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,12 +39,13 @@ uv tool install .
 明示的に上書きする方法:
 
 - 設定ファイルで指定: TOML 中の相対パスは設定ファイル自身のディレクトリ基準で解決されます。
-  同梱の雛形を `--config` でそのまま渡すと、出力もテンプレート自身のディレクトリ配下に
-  書き込まれます（リポジトリ内ならソースツリー、`uv tool install .` 後ならインストール
-  された wheel の site-packages 配下）。通常は `meeting-minutes config init` で
-  `~/.config/meeting-minutes/config.toml` にコピーしてから編集してください。
-  なお `config init` で書き出される雛形は `[output] base_dir` をコメントアウトしているため、
-  そのまま使えば `$XDG_DATA_HOME/meeting-minutes/output/` に出力されます。
+  同梱の雛形は `[output] base_dir` を含むパス系フィールドがコメントアウトされているため、
+  そのまま `--config` で渡しても出力先は XDG 既定 (`$XDG_DATA_HOME/meeting-minutes/output/`)
+  のままです。雛形のコメントを外して相対値（例 `base_dir = "output"`）を書いた場合のみ、
+  その設定ファイル自身のディレクトリ配下に出力されます（リポジトリ内ならソースツリー、
+  `uv tool install .` 後ならインストールされた wheel の site-packages 配下）。
+  通常は `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` に
+  コピーしてから編集してください。
 - 環境変数で指定: `MEETING_MINUTES_OUTPUT__BASE_DIR=path` を設定すると env 経路で
   上書きされ、相対パスは cwd 基準（=従来どおり）として扱われます。設定ファイル
   と異なり anchor されません。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "pydantic-settings>=2.2.0",
   "rich>=13.7.0",
   "sounddevice>=0.4.6",
+  "tomli-w>=1.0.0",
   "typer>=0.12.0",
   "uvicorn[standard]>=0.29.0",
 ]

--- a/src/meeting_minutes/cli.py
+++ b/src/meeting_minutes/cli.py
@@ -9,6 +9,7 @@ from rich.table import Table
 
 from meeting_minutes.audio.devices import list_input_devices
 from meeting_minutes.config import apply_overrides, load_config
+from meeting_minutes.config.cli import config_app
 from meeting_minutes.core.checks import run_checks
 from meeting_minutes.daemon.cli import daemon_app
 from meeting_minutes.errors import MeetingMinutesError
@@ -16,6 +17,7 @@ from meeting_minutes.minutes.summarize import MinutesMode
 
 app = typer.Typer(no_args_is_help=True)
 app.add_typer(daemon_app, name="daemon")
+app.add_typer(config_app, name="config")
 console = Console()
 
 

--- a/src/meeting_minutes/config/__init__.py
+++ b/src/meeting_minutes/config/__init__.py
@@ -1,11 +1,16 @@
 """アプリ全体の設定を pydantic モデルで定義し、TOML / 環境変数 / CLI 上書きから組み立てる。"""
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# config init で雛形として配るファイル。`src/meeting_minutes/config/templates/` 配下に置き、
+# `importlib.resources` でパッケージデータとして参照する（インストール後の wheel でも解決する）。
+_TEMPLATE_FILENAME = "config.example.toml"
 
 
 def _xdg_dir(env_var: str, fallback: Path) -> Path:
@@ -186,6 +191,47 @@ class AppConfig(BaseSettings):
     chunking: ChunkingConfig = Field(default_factory=ChunkingConfig)
     vocabulary: VocabularyConfig = Field(default_factory=VocabularyConfig)
     cleaning: CleaningConfig = Field(default_factory=CleaningConfig)
+
+
+ConfigSourceKind = Literal["explicit", "auto_discovered", "defaults"]
+
+
+@dataclass(frozen=True)
+class ConfigSource:
+    """`load_config` がどこから設定を読み込んだかを示すメタデータ。
+
+    `daemon serve` 起動時のログ出力や `meeting-minutes config path` コマンドが、
+    auto-discovery と明示指定と組み込み既定値のみの 3 パターンを区別するために使う。
+    """
+
+    kind: ConfigSourceKind
+    path: Path | None
+
+
+def resolve_config_source(path: Path | None) -> ConfigSource:
+    """`load_config(path)` が参照する設定ソースを返す。読み込みは行わない。
+
+    - `path` が指定された場合: `kind="explicit"`、`path` をそのまま返す（存在チェックなし）。
+    - `path` が None で XDG 既定パスに config.toml がある場合: `kind="auto_discovered"`。
+    - 上記いずれでもない場合: `kind="defaults"`、`path=None`。
+    """
+    if path is not None:
+        return ConfigSource(kind="explicit", path=path)
+    candidate = default_config_path()
+    if candidate.exists():
+        return ConfigSource(kind="auto_discovered", path=candidate)
+    return ConfigSource(kind="defaults", path=None)
+
+
+def read_template_config_text() -> str:
+    """`config init` で雛形として書き出す `config.example.toml` の内容を返す。
+
+    `importlib.resources` 経由で取得することで、リポジトリ内実行・editable install・
+    `uv tool install .` 後の wheel いずれの形態でも解決される。
+    """
+    from importlib.resources import files
+
+    return files(__package__).joinpath("templates", _TEMPLATE_FILENAME).read_text(encoding="utf-8")
 
 
 def load_config(path: Path | None) -> AppConfig:

--- a/src/meeting_minutes/config/__init__.py
+++ b/src/meeting_minutes/config/__init__.py
@@ -212,13 +212,14 @@ def resolve_config_source(path: Path | None) -> ConfigSource:
     """`load_config(path)` が参照する設定ソースを返す。読み込みは行わない。
 
     - `path` が指定された場合: `kind="explicit"`、`path` をそのまま返す（存在チェックなし）。
-    - `path` が None で XDG 既定パスに config.toml がある場合: `kind="auto_discovered"`。
+    - `path` が None で XDG 既定パスに config.toml が「ファイルとして」ある場合:
+      `kind="auto_discovered"`。同名のディレクトリは auto-discovery 対象から除外する。
     - 上記いずれでもない場合: `kind="defaults"`、`path=None`。
     """
     if path is not None:
         return ConfigSource(kind="explicit", path=path)
     candidate = default_config_path()
-    if candidate.exists():
+    if candidate.is_file():
         return ConfigSource(kind="auto_discovered", path=candidate)
     return ConfigSource(kind="defaults", path=None)
 
@@ -246,7 +247,8 @@ def load_config(path: Path | None) -> AppConfig:
     """
     if path is None:
         candidate = default_config_path()
-        if candidate.exists():
+        # ディレクトリ等の同名エントリで auto-discovery がヒットしないよう is_file() を使う。
+        if candidate.is_file():
             path = candidate
         else:
             return AppConfig()

--- a/src/meeting_minutes/config/cli.py
+++ b/src/meeting_minutes/config/cli.py
@@ -24,14 +24,15 @@ config_app = typer.Typer(no_args_is_help=True, help="設定ファイルを管理
 _console = Console()
 
 
-def _appconfig_to_dict(config: AppConfig) -> dict[str, object]:
-    """`AppConfig` を JSON / TOML どちらにも流せるプリミティブな dict に落とす。
+def _appconfig_to_dict(config: AppConfig, *, drop_none: bool) -> dict[str, object]:
+    """`AppConfig` をプリミティブな dict に落とす。
 
-    `mode="json"` で `Path` / `datetime` を文字列化する。`exclude_none=True` で
-    None フィールドを落とすのは TOML が null を表現できないため（dotted key を
-    `None` のまま `tomli_w.dumps` に渡すと `TypeError` になる）。
+    `mode="json"` で `Path` / `datetime` を文字列化する。`drop_none=True` の場合は
+    None フィールドを落とす（TOML は null を表現できず、`tomli_w.dumps` が
+    `TypeError` を出すため必須）。JSON 出力では未設定フィールドの存在自体が情報なので
+    `drop_none=False` で `null` のまま残す。
     """
-    return config.model_dump(mode="json", exclude_none=True)
+    return config.model_dump(mode="json", exclude_none=drop_none)
 
 
 @config_app.command("path")
@@ -99,21 +100,34 @@ def config_show(
     if output_format not in ("toml", "json"):
         raise typer.BadParameter("--format は 'toml' または 'json' を指定してください")
     app_config = load_config(config)
-    data = _appconfig_to_dict(app_config)
     if output_format == "json":
+        data = _appconfig_to_dict(app_config, drop_none=False)
         _console.print_json(json.dumps(data, ensure_ascii=False))
     else:
+        data = _appconfig_to_dict(app_config, drop_none=True)
         # `[section]` を Rich のマークアップとして解釈されないよう markup=False にする。
         _console.print(tomli_w.dumps(data), end="", soft_wrap=True, highlight=False, markup=False)
 
 
 @config_app.command("edit")
-def config_edit() -> None:
+def config_edit(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", help="編集対象の TOML 設定ファイル（XDG 既定以外を編集する場合）"),
+    ] = None,
+) -> None:
     """`$EDITOR` で config を開きます。未設定なら `open(1)` を試みます。
 
-    対象は auto-discovery で解決される既定パスです。ファイルが未作成の場合は
-    先に `meeting-minutes config init` を案内します。
+    `--config` 未指定時は auto-discovery で解決される既定パスを編集対象とし、
+    ファイル未作成の場合は `meeting-minutes config init` を案内します。
+    `--config` 明示時はそのファイルが存在すれば直接開きます。
     """
+    if config is not None:
+        if not config.is_file():
+            _console.print(f"[red]設定ファイルが見つかりません: {config}[/red]")
+            raise typer.Exit(code=1)
+        _open_in_editor(config)
+        return
     source = resolve_config_source(None)
     if source.kind == "defaults":
         _console.print(

--- a/src/meeting_minutes/config/cli.py
+++ b/src/meeting_minutes/config/cli.py
@@ -1,0 +1,157 @@
+"""`meeting-minutes config` サブコマンド群の定義。"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Annotated
+
+import tomli_w
+import typer
+from rich.console import Console
+
+from meeting_minutes.config import (
+    AppConfig,
+    ConfigSource,
+    default_config_path,
+    load_config,
+    read_template_config_text,
+    resolve_config_source,
+)
+
+config_app = typer.Typer(no_args_is_help=True, help="設定ファイルを管理します。")
+_console = Console()
+
+
+def _appconfig_to_dict(config: AppConfig) -> dict[str, object]:
+    """`AppConfig` を JSON / TOML どちらにも流せるプリミティブな dict に落とす。
+
+    `mode="json"` で `Path` / `datetime` を文字列化する。`exclude_none=True` で
+    None フィールドを落とすのは TOML が null を表現できないため（dotted key を
+    `None` のまま `tomli_w.dumps` に渡すと `TypeError` になる）。
+    """
+    return config.model_dump(mode="json", exclude_none=True)
+
+
+@config_app.command("path")
+def config_path(
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", help="このパスを評価対象として表示する"),
+    ] = None,
+) -> None:
+    """現在 auto-discovery される config のパスを表示します。
+
+    - `--config` を指定: そのパスを `explicit` として表示。
+    - 指定なし & XDG 既定パスが存在: `auto_discovered` として表示。
+    - いずれでもない: 既定パスを `defaults` として表示（このパスに `config init` で作成可）。
+    """
+    source = resolve_config_source(config)
+    # 長いパスがターミナル幅で折り返されないよう soft_wrap=True で 1 行を保つ。
+    if source.kind == "explicit":
+        assert source.path is not None
+        _console.print("[bold]source:[/bold] explicit")
+        _console.print(f"[bold]path:[/bold] {source.path}", soft_wrap=True)
+        return
+    if source.kind == "auto_discovered":
+        assert source.path is not None
+        _console.print("[bold]source:[/bold] auto_discovered")
+        _console.print(f"[bold]path:[/bold] {source.path}", soft_wrap=True)
+        return
+    # defaults: 設定ファイルは未作成。`config init` の作成先パスを併せて表示する。
+    _console.print("[bold]source:[/bold] defaults (no config file)")
+    _console.print(f"[bold]would-be path:[/bold] {default_config_path()}", soft_wrap=True)
+
+
+@config_app.command("init")
+def config_init(
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="既存ファイルを上書きする"),
+    ] = False,
+) -> None:
+    """XDG 既定パスに config.example.toml の内容で雛形を生成します。"""
+    target = default_config_path()
+    if target.exists() and not force:
+        _console.print(
+            f"[red]既に設定ファイルが存在します: {target}[/red]\n"
+            "[yellow]上書きする場合は --force を指定してください。[/yellow]"
+        )
+        raise typer.Exit(code=1)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(read_template_config_text(), encoding="utf-8")
+    _console.print(f"[green]Created:[/green] {target}")
+
+
+@config_app.command("show")
+def config_show(
+    output_format: Annotated[
+        str,
+        typer.Option("--format", help="出力形式（toml / json）"),
+    ] = "toml",
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", help="TOML設定ファイル"),
+    ] = None,
+) -> None:
+    """解決後の AppConfig 全体を出力します。"""
+    if output_format not in ("toml", "json"):
+        raise typer.BadParameter("--format は 'toml' または 'json' を指定してください")
+    app_config = load_config(config)
+    data = _appconfig_to_dict(app_config)
+    if output_format == "json":
+        _console.print_json(json.dumps(data, ensure_ascii=False))
+    else:
+        # `[section]` を Rich のマークアップとして解釈されないよう markup=False にする。
+        _console.print(tomli_w.dumps(data), end="", soft_wrap=True, highlight=False, markup=False)
+
+
+@config_app.command("edit")
+def config_edit() -> None:
+    """`$EDITOR` で config を開きます。未設定なら `open(1)` を試みます。
+
+    対象は auto-discovery で解決される既定パスです。ファイルが未作成の場合は
+    先に `meeting-minutes config init` を案内します。
+    """
+    source = resolve_config_source(None)
+    if source.kind == "defaults":
+        _console.print(
+            f"[red]設定ファイルが存在しません: {default_config_path()}[/red]\n"
+            "[yellow]先に `meeting-minutes config init` で作成してください。[/yellow]"
+        )
+        raise typer.Exit(code=1)
+    assert source.path is not None
+    _open_in_editor(source.path)
+
+
+def _open_in_editor(path: Path) -> None:
+    """`$EDITOR` が設定されていればそれで、なければ macOS の `open(1)` で開く。
+
+    `$EDITOR` をシェルに通すと引数解釈の差異で誤動作するため、`shlex.split` で分解して
+    直接 argv を組み立てる。
+    """
+    import shlex
+
+    editor = os.environ.get("EDITOR")
+    if editor:
+        argv = shlex.split(editor) + [str(path)]
+        subprocess.run(argv, check=True)
+        return
+    open_bin = shutil.which("open")
+    if open_bin is None:
+        _console.print(
+            "[red]$EDITOR が未設定で、`open(1)` も見つかりません。[/red]\n"
+            f"[yellow]手動で開いてください: {path}[/yellow]"
+        )
+        raise typer.Exit(code=1)
+    subprocess.run([open_bin, str(path)], check=True)
+
+
+def describe_config_source(source: ConfigSource) -> str:
+    """ログ出力向けに `ConfigSource` を一行文字列に整形する（daemon serve から共有）。"""
+    if source.kind == "explicit":
+        return f"explicit ({source.path})"
+    if source.kind == "auto_discovered":
+        return f"auto_discovered ({source.path})"
+    return f"defaults (no config file at {default_config_path()})"

--- a/src/meeting_minutes/config/cli.py
+++ b/src/meeting_minutes/config/cli.py
@@ -108,9 +108,8 @@ def config_show(
     # `config edit` と整合させ、`--config <missing>` で raw FileNotFoundError traceback が
     # 出ないよう、明示指定時のみ事前チェックする。auto-discovery 時は load_config 側で
     # 既定値にフォールバックするためチェック不要。
-    if config is not None and not config.is_file():
-        _console.print(f"[red]設定ファイルが見つかりません: {config}[/red]")
-        raise typer.Exit(code=1)
+    if config is not None:
+        _require_regular_file(config)
     app_config = load_config(config)
     if output_format == "json":
         data = _appconfig_to_dict(app_config, drop_none=False)
@@ -135,9 +134,7 @@ def config_edit(
     `--config` 明示時はそのファイルが存在すれば直接開きます。
     """
     if config is not None:
-        if not config.is_file():
-            _console.print(f"[red]設定ファイルが見つかりません: {config}[/red]")
-            raise typer.Exit(code=1)
+        _require_regular_file(config)
         _open_in_editor(config)
         return
     source = resolve_config_source(None)
@@ -157,6 +154,20 @@ def config_edit(
         raise typer.Exit(code=1)
     assert source.path is not None
     _open_in_editor(source.path)
+
+
+def _require_regular_file(path: Path) -> None:
+    """`--config` で渡されたパスが通常ファイルであることを担保する。
+
+    存在しない場合と、存在するが dir / 壊れた symlink などの場合を区別して報告する
+    ことで、`--config <dir>` を間違って渡した際の原因切り分けを楽にする。
+    """
+    if not path.exists():
+        _console.print(f"[red]設定ファイルが見つかりません: {path}[/red]")
+        raise typer.Exit(code=1)
+    if not path.is_file():
+        _console.print(f"[red]設定ファイルパスが通常ファイルではありません: {path}[/red]")
+        raise typer.Exit(code=1)
 
 
 def _open_in_editor(path: Path) -> None:

--- a/src/meeting_minutes/config/cli.py
+++ b/src/meeting_minutes/config/cli.py
@@ -74,18 +74,12 @@ def config_init(
 ) -> None:
     """XDG 既定パスに config.example.toml の内容で雛形を生成します。"""
     target = default_config_path()
-    if target.exists():
-        if not target.is_file():
-            # ディレクトリ等の通常ファイルでないエントリは --force でも書き込めないため、
-            # `write_text` が `IsADirectoryError` を出す前に明示的に弾く。
-            _console.print(f"[red]設定ファイルパスが通常ファイルではありません: {target}[/red]")
-            raise typer.Exit(code=1)
-        if not force:
-            _console.print(
-                f"[red]既に設定ファイルが存在します: {target}[/red]\n"
-                "[yellow]上書きする場合は --force を指定してください。[/yellow]"
-            )
-            raise typer.Exit(code=1)
+    if target.exists() and not force:
+        _console.print(
+            f"[red]既に設定ファイルが存在します: {target}[/red]\n"
+            "[yellow]上書きする場合は --force を指定してください。[/yellow]"
+        )
+        raise typer.Exit(code=1)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(read_template_config_text(), encoding="utf-8")
     _console.print(f"[green]Created:[/green] {target}")
@@ -139,16 +133,8 @@ def config_edit(
         return
     source = resolve_config_source(None)
     if source.kind == "defaults":
-        # 既定パスに dir 等の通常ファイルでないエントリがある場合、`config init` も
-        # 同じ理由で失敗するため案内せず、実際の問題をそのまま表示する。
-        default_path = default_config_path()
-        if default_path.exists():
-            _console.print(
-                f"[red]設定ファイルパスが通常ファイルではありません: {default_path}[/red]"
-            )
-            raise typer.Exit(code=1)
         _console.print(
-            f"[red]設定ファイルが存在しません: {default_path}[/red]\n"
+            f"[red]設定ファイルが存在しません: {default_config_path()}[/red]\n"
             "[yellow]先に `meeting-minutes config init` で作成してください。[/yellow]"
         )
         raise typer.Exit(code=1)
@@ -157,16 +143,15 @@ def config_edit(
 
 
 def _require_regular_file(path: Path) -> None:
-    """`--config` で渡されたパスが通常ファイルであることを担保する。
+    """`--config` で渡されたパスが通常ファイルでなければ CLI エラーで弾く。
 
-    存在しない場合と、存在するが dir / 壊れた symlink などの場合を区別して報告する
-    ことで、`--config <dir>` を間違って渡した際の原因切り分けを楽にする。
+    `is_file()` 一発で「存在しない」「dir」「壊れた symlink」を一括して判定し、
+    pydantic-settings が tomllib に dir を渡して曖昧なエラーになる事態を防ぐ。
     """
-    if not path.exists():
-        _console.print(f"[red]設定ファイルが見つかりません: {path}[/red]")
-        raise typer.Exit(code=1)
     if not path.is_file():
-        _console.print(f"[red]設定ファイルパスが通常ファイルではありません: {path}[/red]")
+        _console.print(
+            f"[red]設定ファイルが見つかりません（または通常ファイルではありません）: {path}[/red]"
+        )
         raise typer.Exit(code=1)
 
 

--- a/src/meeting_minutes/config/cli.py
+++ b/src/meeting_minutes/config/cli.py
@@ -74,12 +74,18 @@ def config_init(
 ) -> None:
     """XDG 既定パスに config.example.toml の内容で雛形を生成します。"""
     target = default_config_path()
-    if target.exists() and not force:
-        _console.print(
-            f"[red]既に設定ファイルが存在します: {target}[/red]\n"
-            "[yellow]上書きする場合は --force を指定してください。[/yellow]"
-        )
-        raise typer.Exit(code=1)
+    if target.exists():
+        if not target.is_file():
+            # ディレクトリ等の通常ファイルでないエントリは --force でも書き込めないため、
+            # `write_text` が `IsADirectoryError` を出す前に明示的に弾く。
+            _console.print(f"[red]設定ファイルパスが通常ファイルではありません: {target}[/red]")
+            raise typer.Exit(code=1)
+        if not force:
+            _console.print(
+                f"[red]既に設定ファイルが存在します: {target}[/red]\n"
+                "[yellow]上書きする場合は --force を指定してください。[/yellow]"
+            )
+            raise typer.Exit(code=1)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(read_template_config_text(), encoding="utf-8")
     _console.print(f"[green]Created:[/green] {target}")

--- a/src/meeting_minutes/config/cli.py
+++ b/src/meeting_minutes/config/cli.py
@@ -105,6 +105,12 @@ def config_show(
     """解決後の AppConfig 全体を出力します。"""
     if output_format not in ("toml", "json"):
         raise typer.BadParameter("--format は 'toml' または 'json' を指定してください")
+    # `config edit` と整合させ、`--config <missing>` で raw FileNotFoundError traceback が
+    # 出ないよう、明示指定時のみ事前チェックする。auto-discovery 時は load_config 側で
+    # 既定値にフォールバックするためチェック不要。
+    if config is not None and not config.is_file():
+        _console.print(f"[red]設定ファイルが見つかりません: {config}[/red]")
+        raise typer.Exit(code=1)
     app_config = load_config(config)
     if output_format == "json":
         data = _appconfig_to_dict(app_config, drop_none=False)
@@ -136,8 +142,16 @@ def config_edit(
         return
     source = resolve_config_source(None)
     if source.kind == "defaults":
+        # 既定パスに dir 等の通常ファイルでないエントリがある場合、`config init` も
+        # 同じ理由で失敗するため案内せず、実際の問題をそのまま表示する。
+        default_path = default_config_path()
+        if default_path.exists():
+            _console.print(
+                f"[red]設定ファイルパスが通常ファイルではありません: {default_path}[/red]"
+            )
+            raise typer.Exit(code=1)
         _console.print(
-            f"[red]設定ファイルが存在しません: {default_config_path()}[/red]\n"
+            f"[red]設定ファイルが存在しません: {default_path}[/red]\n"
             "[yellow]先に `meeting-minutes config init` で作成してください。[/yellow]"
         )
         raise typer.Exit(code=1)

--- a/src/meeting_minutes/config/templates/config.example.toml
+++ b/src/meeting_minutes/config/templates/config.example.toml
@@ -49,8 +49,8 @@ think = false
 [output]
 # 未指定時は $XDG_DATA_HOME/meeting-minutes/output/ (~/.local/share/meeting-minutes/output/) に保存される。
 # 相対パスを書いた場合は本ファイルが置かれているディレクトリ基準で解決される。
-# 例: 本ファイルをリポ直下から `--config config.example.toml` で渡すと `<repo>/output/`、
-# `~/.config/meeting-minutes/config.toml` にコピーすると `~/.config/meeting-minutes/output/` になる。
+# 例: `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` にコピーすると
+# `~/.config/meeting-minutes/output/` になる。
 # 任意の場所に固定したい場合は絶対パスを指定する。
 base_dir = "output"
 save_transcript = true

--- a/src/meeting_minutes/config/templates/config.example.toml
+++ b/src/meeting_minutes/config/templates/config.example.toml
@@ -47,12 +47,12 @@ timeout_seconds = 600
 think = false
 
 [output]
-# 未指定時は $XDG_DATA_HOME/meeting-minutes/output/ (~/.local/share/meeting-minutes/output/) に保存される。
-# 相対パスを書いた場合は本ファイルが置かれているディレクトリ基準で解決される。
-# 例: `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` にコピーすると
-# `~/.config/meeting-minutes/output/` になる。
-# 任意の場所に固定したい場合は絶対パスを指定する。
-base_dir = "output"
+# base_dir 未指定時は $XDG_DATA_HOME/meeting-minutes/output/ (~/.local/share/meeting-minutes/output/) に保存される。
+# `meeting-minutes config init` でコピーした直後はこの XDG 既定で動くよう、base_dir はコメントアウトしている。
+# 別の場所に出したい場合は以下を有効化する:
+# - 相対パス: 本設定ファイル自身のディレクトリ基準で解決される（cwd 非依存）。
+# - 絶対パス: 指定どおりの場所に固定される。
+# base_dir = "output"
 save_transcript = true
 save_audio = true
 

--- a/src/meeting_minutes/daemon/cli.py
+++ b/src/meeting_minutes/daemon/cli.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 if TYPE_CHECKING:
+    import logging
+
     import httpx
 
     from meeting_minutes.daemon.client import DaemonClient as DaemonClientType
@@ -13,7 +15,8 @@ if TYPE_CHECKING:
 import typer
 from rich.console import Console
 
-from meeting_minutes.config import load_config
+from meeting_minutes.config import load_config, resolve_config_source
+from meeting_minutes.config.cli import describe_config_source
 
 daemon_app = typer.Typer(no_args_is_help=True, help="ローカル制御サーバを管理します。")
 _console = Console()
@@ -73,6 +76,42 @@ def _invoke_daemon(
         raise typer.Exit(code=1) from exc
 
 
+_DAEMON_LOGGER_NAME = "meeting_minutes.daemon"
+
+
+def _ensure_daemon_logger() -> "logging.Logger":
+    """daemon serve 起動時に使うロガーを準備する。
+
+    uvicorn は自身のログ設定で root ロガーを書き換えるため、専用のハンドラを
+    `propagate=False` で持たせ、書式を固定する。再呼び出し時に重複ハンドラを
+    付けないようガードする。
+    """
+    import logging
+
+    logger = logging.getLogger(_DAEMON_LOGGER_NAME)
+    if not any(getattr(h, "_meeting_minutes_daemon", False) for h in logger.handlers):
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        handler._meeting_minutes_daemon = True  # type: ignore[attr-defined]
+        logger.addHandler(handler)
+        logger.propagate = False
+    logger.setLevel(logging.INFO)
+    return logger
+
+
+def _log_daemon_startup(
+    logger: "logging.Logger",
+    *,
+    source_description: str,
+    output_base_dir: Path,
+    port: int,
+) -> None:
+    """daemon 起動時の参照先 / 待ち受け先を一括で INFO 出力する。"""
+    logger.info("config source: %s", source_description)
+    logger.info("output base_dir: %s", output_base_dir)
+    logger.info("listening on http://127.0.0.1:%d", port)
+
+
 @daemon_app.command("serve")
 def daemon_serve(
     port: Annotated[int, typer.Option("--port", min=1, max=65535)] = 8765,
@@ -84,8 +123,19 @@ def daemon_serve(
     from meeting_minutes.daemon.server import app as daemon_server_app
     from meeting_minutes.daemon.server import configure
 
+    source = resolve_config_source(config)
     app_config = load_config(config)
     configure(app_config)
+
+    # uvicorn の起動ログ (`Uvicorn running on http://127.0.0.1:8765`) より前に
+    # config / output 解決結果を出すことで、どの設定で動いているかを最初の数行で把握できる。
+    _log_daemon_startup(
+        _ensure_daemon_logger(),
+        source_description=describe_config_source(source),
+        output_base_dir=app_config.output.base_dir,
+        port=port,
+    )
+
     uvicorn.run(daemon_server_app, host="127.0.0.1", port=port)
 
 

--- a/src/meeting_minutes/daemon/cli.py
+++ b/src/meeting_minutes/daemon/cli.py
@@ -104,12 +104,15 @@ def _log_daemon_startup(
     *,
     source_description: str,
     output_base_dir: Path,
-    port: int,
 ) -> None:
-    """daemon 起動時の参照先 / 待ち受け先を一括で INFO 出力する。"""
+    """daemon 起動時の参照先（config / output）を INFO 出力する。
+
+    待ち受けアドレスは uvicorn 自身が `Uvicorn running on http://...` を出すので
+    ここでは出力しない（uvicorn より先に出すと、bind 失敗時にも
+    listening 表示が残って誤解を招くため）。
+    """
     logger.info("config source: %s", source_description)
     logger.info("output base_dir: %s", output_base_dir)
-    logger.info("listening on http://127.0.0.1:%d", port)
 
 
 @daemon_app.command("serve")
@@ -133,7 +136,6 @@ def daemon_serve(
         _ensure_daemon_logger(),
         source_description=describe_config_source(source),
         output_base_dir=app_config.output.base_dir,
-        port=port,
     )
 
     uvicorn.run(daemon_server_app, host="127.0.0.1", port=port)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,10 @@ from meeting_minutes.config import (
     VadConfig,
     appconfig_section_names,
     apply_overrides,
+    default_config_path,
     load_config,
+    read_template_config_text,
+    resolve_config_source,
 )
 
 
@@ -56,7 +59,7 @@ ollama_model = "gemma4:latest"
 
 
 def test_example_config_loads() -> None:
-    config = load_config(Path("config.example.toml"))
+    config = load_config(Path("src/meeting_minutes/config/templates/config.example.toml"))
 
     assert config.audio.device == "BlackHole 2ch"
 
@@ -114,7 +117,7 @@ def test_vad_config_rejects_frame_longer_than_max() -> None:
 
 
 def test_example_config_loads_cleaning_section() -> None:
-    config = load_config(Path("config.example.toml"))
+    config = load_config(Path("src/meeting_minutes/config/templates/config.example.toml"))
 
     assert config.cleaning.chunk_size == 4000
     assert config.cleaning.output_filename == "transcript_clean.md"
@@ -314,3 +317,48 @@ def test_apply_overrides_accepts_all_appconfig_sections() -> None:
         override_value = _make_different_value(current_value)
         result = apply_overrides(config, {f"{section}.{field_name}": override_value})
         assert getattr(getattr(result, section), field_name) == override_value
+
+
+class TestResolveConfigSource:
+    def test_returns_explicit_when_path_given(self, tmp_path: Path) -> None:
+        explicit = tmp_path / "explicit.toml"
+        # 明示指定は存在チェックを行わない（load_config 側のエラーに任せる）
+        source = resolve_config_source(explicit)
+        assert source.kind == "explicit"
+        assert source.path == explicit
+
+    def test_returns_auto_discovered_when_xdg_config_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").touch()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        source = resolve_config_source(None)
+
+        assert source.kind == "auto_discovered"
+        assert source.path == default_config_path()
+
+    def test_returns_defaults_when_no_config_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+
+        source = resolve_config_source(None)
+
+        assert source.kind == "defaults"
+        assert source.path is None
+
+
+def test_read_template_config_text_returns_loadable_toml() -> None:
+    """`config init` で書き出す内容がそのまま `load_config` で読み込めることを保証する。"""
+    import tomllib
+
+    text = read_template_config_text()
+
+    # TOML としてパース可能
+    tomllib.loads(text)
+    # AppConfig としても妥当
+    assert "[audio]" in text
+    assert "[output]" in text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -350,6 +350,21 @@ class TestResolveConfigSource:
         assert source.kind == "defaults"
         assert source.path is None
 
+    def test_treats_directory_at_default_path_as_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """既定パスに同名ディレクトリがあっても auto-discovery しない（is_file 判定）。"""
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        # config.toml という名前のディレクトリを置いてみる
+        (config_dir / "config.toml").mkdir()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        source = resolve_config_source(None)
+
+        assert source.kind == "defaults"
+        assert source.path is None
+
 
 def test_read_template_config_text_returns_loadable_toml() -> None:
     """`config init` で書き出す内容がそのまま `load_config` で読み込めることを保証する。"""

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -104,12 +104,34 @@ class TestConfigShow:
         assert "audio" in data
         assert "output" in data
 
+    def test_json_preserves_null_for_unset_fields(self, runner: CliRunner) -> None:
+        """JSON は null を表現できるので、未設定フィールド (audio.device など) を残す。
+
+        TOML 出力が exclude_none=True なのは TOML 側の制約であって、JSON にまで
+        その挙動を引きずらないことを担保する。
+        """
+        result = runner.invoke(app, ["config", "show", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        # 既定で None のフィールドが null として保持されている
+        assert data["audio"]["device"] is None
+        assert data["audio"]["device_index"] is None
+        assert data["vocabulary"]["glossary_file"] is None
+
     def test_outputs_toml_with_section_headers(self, runner: CliRunner) -> None:
         result = runner.invoke(app, ["config", "show", "--format", "toml"])
         assert result.exit_code == 0
         assert "[audio]" in result.stdout
         # 出力は TOML として再パース可能
         tomllib.loads(result.stdout)
+
+    def test_toml_drops_null_fields(self, runner: CliRunner) -> None:
+        """TOML は null を表現できないため、None フィールドは出力から落とす必要がある。"""
+        result = runner.invoke(app, ["config", "show", "--format", "toml"])
+        assert result.exit_code == 0
+        parsed = tomllib.loads(result.stdout)
+        assert "device" not in parsed["audio"]
+        assert "glossary_file" not in parsed["vocabulary"]
 
     def test_rejects_unknown_format(self, runner: CliRunner) -> None:
         result = runner.invoke(app, ["config", "show", "--format", "yaml"])
@@ -142,3 +164,58 @@ class TestConfigEdit:
 
         assert result.exit_code == 1
         assert "config init" in result.stdout
+
+    def test_falls_back_to_open_when_editor_unset(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        target = config_dir / "config.toml"
+        target.touch()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        monkeypatch.delenv("EDITOR", raising=False)
+
+        with (
+            patch("meeting_minutes.config.cli.shutil.which", return_value="/usr/bin/open"),
+            patch("meeting_minutes.config.cli.subprocess.run") as run_mock,
+        ):
+            result = runner.invoke(app, ["config", "edit"])
+
+        assert result.exit_code == 0
+        run_mock.assert_called_once_with(["/usr/bin/open", str(target)], check=True)
+
+    def test_errors_when_editor_unset_and_open_missing(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").touch()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        monkeypatch.delenv("EDITOR", raising=False)
+
+        with patch("meeting_minutes.config.cli.shutil.which", return_value=None):
+            result = runner.invoke(app, ["config", "edit"])
+
+        assert result.exit_code == 1
+        assert "open(1)" in result.stdout
+
+    def test_opens_explicit_config_when_path_option_given(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        explicit = tmp_path / "alt.toml"
+        explicit.touch()
+        # XDG 側に config が無くても --config 経由で開けることを確認する。
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.setenv("EDITOR", "fake-editor")
+
+        with patch("meeting_minutes.config.cli.subprocess.run") as run_mock:
+            result = runner.invoke(app, ["config", "edit", "--config", str(explicit)])
+
+        assert result.exit_code == 0
+        run_mock.assert_called_once_with(["fake-editor", str(explicit)], check=True)
+
+    def test_errors_when_explicit_config_missing(self, runner: CliRunner, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["config", "edit", "--config", str(tmp_path / "missing.toml")])
+
+        assert result.exit_code == 1
+        assert "見つかりません" in result.stdout

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -1,0 +1,144 @@
+"""`meeting-minutes config` サブコマンド群のテスト。"""
+
+import json
+import tomllib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from meeting_minutes.cli import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestConfigPath:
+    def test_shows_explicit_when_config_option_given(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        explicit = tmp_path / "explicit.toml"
+        result = runner.invoke(app, ["config", "path", "--config", str(explicit)])
+        assert result.exit_code == 0
+        assert "source: explicit" in result.stdout
+        assert str(explicit) in result.stdout
+
+    def test_shows_auto_discovered_when_xdg_config_exists(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").touch()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        result = runner.invoke(app, ["config", "path"])
+
+        assert result.exit_code == 0
+        assert "source: auto_discovered" in result.stdout
+
+    def test_shows_defaults_when_no_config_found(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+
+        result = runner.invoke(app, ["config", "path"])
+
+        assert result.exit_code == 0
+        assert "source: defaults" in result.stdout
+        assert "would-be path:" in result.stdout
+
+
+class TestConfigInit:
+    def test_creates_template_at_xdg_default_path(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        result = runner.invoke(app, ["config", "init"])
+
+        assert result.exit_code == 0
+        target = tmp_path / "config" / "meeting-minutes" / "config.toml"
+        assert target.exists()
+        # 書き出した内容は TOML として妥当
+        tomllib.loads(target.read_text(encoding="utf-8"))
+
+    def test_refuses_to_overwrite_without_force(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        target = config_dir / "config.toml"
+        target.write_text("# existing content\n", encoding="utf-8")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        result = runner.invoke(app, ["config", "init"])
+
+        assert result.exit_code == 1
+        # 既存ファイルは保持される
+        assert target.read_text(encoding="utf-8") == "# existing content\n"
+
+    def test_overwrites_when_force_specified(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        target = config_dir / "config.toml"
+        target.write_text("# existing\n", encoding="utf-8")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        result = runner.invoke(app, ["config", "init", "--force"])
+
+        assert result.exit_code == 0
+        assert target.read_text(encoding="utf-8") != "# existing\n"
+
+
+class TestConfigShow:
+    def test_outputs_json_with_resolved_appconfig(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["config", "show", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        # 解決後の AppConfig セクションが含まれる
+        assert "audio" in data
+        assert "output" in data
+
+    def test_outputs_toml_with_section_headers(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["config", "show", "--format", "toml"])
+        assert result.exit_code == 0
+        assert "[audio]" in result.stdout
+        # 出力は TOML として再パース可能
+        tomllib.loads(result.stdout)
+
+    def test_rejects_unknown_format(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["config", "show", "--format", "yaml"])
+        assert result.exit_code != 0
+
+
+class TestConfigEdit:
+    def test_invokes_editor_on_resolved_config_path(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        target = config_dir / "config.toml"
+        target.touch()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        monkeypatch.setenv("EDITOR", "fake-editor")
+
+        with patch("meeting_minutes.config.cli.subprocess.run") as run_mock:
+            result = runner.invoke(app, ["config", "edit"])
+
+        assert result.exit_code == 0
+        run_mock.assert_called_once_with(["fake-editor", str(target)], check=True)
+
+    def test_errors_when_no_config_file_exists(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+
+        result = runner.invoke(app, ["config", "edit"])
+
+        assert result.exit_code == 1
+        assert "config init" in result.stdout

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -175,6 +175,14 @@ class TestConfigShow:
         result = runner.invoke(app, ["config", "show", "--format", "yaml"])
         assert result.exit_code != 0
 
+    def test_errors_when_explicit_config_missing(self, runner: CliRunner, tmp_path: Path) -> None:
+        """`config edit` と整合させ、--config 明示指定で存在しないパスは
+        traceback ではなく CLI エラーで弾く。"""
+        result = runner.invoke(app, ["config", "show", "--config", str(tmp_path / "missing.toml")])
+
+        assert result.exit_code == 1
+        assert "見つかりません" in result.stdout
+
 
 class TestConfigEdit:
     def test_invokes_editor_on_resolved_config_path(
@@ -257,3 +265,21 @@ class TestConfigEdit:
 
         assert result.exit_code == 1
         assert "見つかりません" in result.stdout
+
+    def test_errors_when_default_path_is_directory(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """既定パスに dir があるときは `config init` を案内せず、実際の問題を出す。
+
+        `config init` も同じ理由で失敗するため、案内を出すと dead-end になる。
+        """
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").mkdir()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        result = runner.invoke(app, ["config", "edit"])
+
+        assert result.exit_code == 1
+        assert "通常ファイルではありません" in result.stdout
+        assert "config init" not in result.stdout

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -183,6 +183,19 @@ class TestConfigShow:
         assert result.exit_code == 1
         assert "見つかりません" in result.stdout
 
+    def test_errors_when_explicit_config_is_directory(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """`--config` に dir を渡したときは「見つかりません」ではなく
+        「通常ファイルではない」と報告して原因切り分けを助ける。"""
+        explicit_dir = tmp_path / "config-dir"
+        explicit_dir.mkdir()
+
+        result = runner.invoke(app, ["config", "show", "--config", str(explicit_dir)])
+
+        assert result.exit_code == 1
+        assert "通常ファイルではありません" in result.stdout
+
 
 class TestConfigEdit:
     def test_invokes_editor_on_resolved_config_path(
@@ -265,6 +278,17 @@ class TestConfigEdit:
 
         assert result.exit_code == 1
         assert "見つかりません" in result.stdout
+
+    def test_errors_when_explicit_config_is_directory(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        explicit_dir = tmp_path / "config-dir"
+        explicit_dir.mkdir()
+
+        result = runner.invoke(app, ["config", "edit", "--config", str(explicit_dir)])
+
+        assert result.exit_code == 1
+        assert "通常ファイルではありません" in result.stdout
 
     def test_errors_when_default_path_is_directory(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -80,6 +80,44 @@ class TestConfigInit:
         # 既存ファイルは保持される
         assert target.read_text(encoding="utf-8") == "# existing content\n"
 
+    def test_init_does_not_override_xdg_default_output_dir(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`config init` 直後は XDG 既定の output ディレクトリ
+        (`$XDG_DATA_HOME/meeting-minutes/output/`) が使われる必要がある。
+
+        テンプレートに `base_dir = "output"` が有効化された状態だと、相対パスが
+        config ファイルのディレクトリ基準で anchor されて XDG データ既定が
+        サイレントに無効化される。テンプレート側で base_dir をコメントアウト
+        しているため、`config init` した直後の `load_config` は XDG 既定の
+        `<XDG_DATA_HOME>/meeting-minutes/output/` を返す。
+        """
+        from meeting_minutes.config import load_config
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+        result = runner.invoke(app, ["config", "init"])
+        assert result.exit_code == 0
+
+        config = load_config(None)
+        assert config.output.base_dir == tmp_path / "data" / "meeting-minutes" / "output"
+
+    def test_errors_when_target_path_is_directory(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`config init --force` でも対象が dir なら write_text を呼ばずに弾く。"""
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        # config.toml をディレクトリとして作る
+        (config_dir / "config.toml").mkdir()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        result = runner.invoke(app, ["config", "init", "--force"])
+
+        assert result.exit_code == 1
+        assert "通常ファイルではありません" in result.stdout
+
     def test_overwrites_when_force_specified(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -103,21 +103,6 @@ class TestConfigInit:
         config = load_config(None)
         assert config.output.base_dir == tmp_path / "data" / "meeting-minutes" / "output"
 
-    def test_errors_when_target_path_is_directory(
-        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """`config init --force` でも対象が dir なら write_text を呼ばずに弾く。"""
-        config_dir = tmp_path / "config" / "meeting-minutes"
-        config_dir.mkdir(parents=True)
-        # config.toml をディレクトリとして作る
-        (config_dir / "config.toml").mkdir()
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
-
-        result = runner.invoke(app, ["config", "init", "--force"])
-
-        assert result.exit_code == 1
-        assert "通常ファイルではありません" in result.stdout
-
     def test_overwrites_when_force_specified(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -175,26 +160,21 @@ class TestConfigShow:
         result = runner.invoke(app, ["config", "show", "--format", "yaml"])
         assert result.exit_code != 0
 
-    def test_errors_when_explicit_config_missing(self, runner: CliRunner, tmp_path: Path) -> None:
-        """`config edit` と整合させ、--config 明示指定で存在しないパスは
-        traceback ではなく CLI エラーで弾く。"""
-        result = runner.invoke(app, ["config", "show", "--config", str(tmp_path / "missing.toml")])
-
-        assert result.exit_code == 1
-        assert "見つかりません" in result.stdout
-
-    def test_errors_when_explicit_config_is_directory(
+    def test_errors_when_explicit_config_not_a_regular_file(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        """`--config` に dir を渡したときは「見つかりません」ではなく
-        「通常ファイルではない」と報告して原因切り分けを助ける。"""
-        explicit_dir = tmp_path / "config-dir"
-        explicit_dir.mkdir()
+        """`config edit` と整合させ、--config 明示指定で通常ファイルでないパスは
+        traceback ではなく CLI エラーで弾く（missing / dir / 壊れた symlink を一括処理）。"""
+        missing = tmp_path / "missing.toml"
+        result_missing = runner.invoke(app, ["config", "show", "--config", str(missing)])
+        assert result_missing.exit_code == 1
+        assert "見つかりません" in result_missing.stdout
 
-        result = runner.invoke(app, ["config", "show", "--config", str(explicit_dir)])
-
-        assert result.exit_code == 1
-        assert "通常ファイルではありません" in result.stdout
+        dir_path = tmp_path / "config-dir"
+        dir_path.mkdir()
+        result_dir = runner.invoke(app, ["config", "show", "--config", str(dir_path)])
+        assert result_dir.exit_code == 1
+        assert "見つかりません" in result_dir.stdout
 
 
 class TestConfigEdit:
@@ -273,37 +253,17 @@ class TestConfigEdit:
         assert result.exit_code == 0
         run_mock.assert_called_once_with(["fake-editor", str(explicit)], check=True)
 
-    def test_errors_when_explicit_config_missing(self, runner: CliRunner, tmp_path: Path) -> None:
-        result = runner.invoke(app, ["config", "edit", "--config", str(tmp_path / "missing.toml")])
-
-        assert result.exit_code == 1
-        assert "見つかりません" in result.stdout
-
-    def test_errors_when_explicit_config_is_directory(
+    def test_errors_when_explicit_config_not_a_regular_file(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        explicit_dir = tmp_path / "config-dir"
-        explicit_dir.mkdir()
+        """--config に missing / dir を渡したときは traceback ではなく CLI エラーで弾く。"""
+        missing = tmp_path / "missing.toml"
+        result_missing = runner.invoke(app, ["config", "edit", "--config", str(missing)])
+        assert result_missing.exit_code == 1
+        assert "見つかりません" in result_missing.stdout
 
-        result = runner.invoke(app, ["config", "edit", "--config", str(explicit_dir)])
-
-        assert result.exit_code == 1
-        assert "通常ファイルではありません" in result.stdout
-
-    def test_errors_when_default_path_is_directory(
-        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """既定パスに dir があるときは `config init` を案内せず、実際の問題を出す。
-
-        `config init` も同じ理由で失敗するため、案内を出すと dead-end になる。
-        """
-        config_dir = tmp_path / "config" / "meeting-minutes"
-        config_dir.mkdir(parents=True)
-        (config_dir / "config.toml").mkdir()
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
-
-        result = runner.invoke(app, ["config", "edit"])
-
-        assert result.exit_code == 1
-        assert "通常ファイルではありません" in result.stdout
-        assert "config init" not in result.stdout
+        dir_path = tmp_path / "config-dir"
+        dir_path.mkdir()
+        result_dir = runner.invoke(app, ["config", "edit", "--config", str(dir_path)])
+        assert result_dir.exit_code == 1
+        assert "見つかりません" in result_dir.stdout

--- a/tests/test_daemon_cli.py
+++ b/tests/test_daemon_cli.py
@@ -1,0 +1,122 @@
+"""`meeting-minutes daemon` CLI のテスト（serve 起動時の参照先ログ等）。"""
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from meeting_minutes.config import OutputConfig
+from meeting_minutes.daemon import cli as daemon_cli
+
+
+@pytest.fixture(autouse=True)
+def reset_daemon_logger() -> Iterator[None]:
+    """`_ensure_daemon_logger` が `propagate=False` を立てるため、
+    そのままだと caplog が記録を拾えない。各テストの前後でロガー状態を初期化する。
+
+    （production では uvicorn のログ二重出力を避けるため `propagate=False` が正しい挙動なので、
+    テスト側でのみ propagate を有効化する。）
+    """
+    logger = logging.getLogger(daemon_cli._DAEMON_LOGGER_NAME)
+    original_handlers = logger.handlers[:]
+    original_propagate = logger.propagate
+    original_level = logger.level
+    logger.handlers = []
+    logger.propagate = True
+    logger.setLevel(logging.NOTSET)
+    yield
+    logger.handlers = original_handlers
+    logger.propagate = original_propagate
+    logger.setLevel(original_level)
+
+
+class TestLogDaemonStartup:
+    def test_emits_three_info_lines_in_order(
+        self, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ) -> None:
+        logger = logging.getLogger(daemon_cli._DAEMON_LOGGER_NAME)
+        with caplog.at_level(logging.INFO, logger=daemon_cli._DAEMON_LOGGER_NAME):
+            daemon_cli._log_daemon_startup(
+                logger,
+                source_description="auto_discovered (/path/to/config.toml)",
+                output_base_dir=tmp_path / "out",
+                port=8765,
+            )
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert messages == [
+            "config source: auto_discovered (/path/to/config.toml)",
+            f"output base_dir: {tmp_path / 'out'}",
+            "listening on http://127.0.0.1:8765",
+        ]
+
+
+class TestEnsureDaemonLogger:
+    def test_does_not_add_duplicate_handler_on_repeat_calls(self) -> None:
+        first = daemon_cli._ensure_daemon_logger()
+        # 初回呼び出しでハンドラが 1 つ付与され、2 回目以降は増えないことを確認する。
+        after_first = len(first.handlers)
+        assert after_first >= 1
+
+        second = daemon_cli._ensure_daemon_logger()
+        assert first is second
+        assert len(second.handlers) == after_first
+
+
+class TestDescribeConfigSourceFromCli:
+    """daemon serve 用に `describe_config_source` がどの種別も識別できることを確認する。"""
+
+    def test_describes_explicit_source(self, tmp_path: Path) -> None:
+        from meeting_minutes.config import resolve_config_source
+        from meeting_minutes.config.cli import describe_config_source
+
+        explicit = tmp_path / "explicit.toml"
+        description = describe_config_source(resolve_config_source(explicit))
+        assert description.startswith("explicit (")
+        assert str(explicit) in description
+
+    def test_describes_auto_discovered_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from meeting_minutes.config import resolve_config_source
+        from meeting_minutes.config.cli import describe_config_source
+
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").touch()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+
+        description = describe_config_source(resolve_config_source(None))
+        assert description.startswith("auto_discovered (")
+
+    def test_describes_defaults_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from meeting_minutes.config import resolve_config_source
+        from meeting_minutes.config.cli import describe_config_source
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+
+        description = describe_config_source(resolve_config_source(None))
+        assert description.startswith("defaults (no config file at ")
+
+
+def test_appconfig_output_base_dir_used_in_log(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """ログには `AppConfig.output.base_dir` の解決結果（XDG 既定 or TOML 上書き）が出る。"""
+    output = OutputConfig(base_dir=tmp_path / "custom-out")
+    logger = logging.getLogger(daemon_cli._DAEMON_LOGGER_NAME)
+
+    with caplog.at_level(logging.INFO, logger=daemon_cli._DAEMON_LOGGER_NAME):
+        daemon_cli._log_daemon_startup(
+            logger,
+            source_description="defaults",
+            output_base_dir=output.base_dir,
+            port=9000,
+        )
+
+    assert any(
+        f"output base_dir: {tmp_path / 'custom-out'}" == r.getMessage() for r in caplog.records
+    )

--- a/tests/test_daemon_cli.py
+++ b/tests/test_daemon_cli.py
@@ -31,8 +31,16 @@ def reset_daemon_logger() -> Iterator[None]:
     logger.setLevel(original_level)
 
 
+def _daemon_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """caplog から daemon ロガー由来のメッセージだけ抜き出す。
+
+    pytest-randomly で他テスト由来の record が混じっても判定が壊れないようにする。
+    """
+    return [r.getMessage() for r in caplog.records if r.name == daemon_cli._DAEMON_LOGGER_NAME]
+
+
 class TestLogDaemonStartup:
-    def test_emits_three_info_lines_in_order(
+    def test_emits_config_and_output_lines_in_order(
         self, caplog: pytest.LogCaptureFixture, tmp_path: Path
     ) -> None:
         logger = logging.getLogger(daemon_cli._DAEMON_LOGGER_NAME)
@@ -41,15 +49,32 @@ class TestLogDaemonStartup:
                 logger,
                 source_description="auto_discovered (/path/to/config.toml)",
                 output_base_dir=tmp_path / "out",
-                port=8765,
             )
 
-        messages = [r.getMessage() for r in caplog.records]
-        assert messages == [
+        assert _daemon_messages(caplog) == [
             "config source: auto_discovered (/path/to/config.toml)",
             f"output base_dir: {tmp_path / 'out'}",
-            "listening on http://127.0.0.1:8765",
         ]
+
+    def test_does_not_emit_listening_line(
+        self, caplog: pytest.LogCaptureFixture, tmp_path: Path
+    ) -> None:
+        """uvicorn が `Uvicorn running on http://...` を自分で出すので、
+        bind 前に重複/虚偽の listening 行を出さないことを担保する。"""
+        logger = logging.getLogger(daemon_cli._DAEMON_LOGGER_NAME)
+        with caplog.at_level(logging.INFO, logger=daemon_cli._DAEMON_LOGGER_NAME):
+            daemon_cli._log_daemon_startup(
+                logger,
+                source_description="defaults",
+                output_base_dir=tmp_path / "out",
+            )
+
+        # "listening on" / "127.0.0.1:" のいずれも daemon ロガー出力に含まれてはならない。
+        # （tmp_path のテスト名にたまたま "listening" が含まれるケースを避けるため、
+        # より具体的な部分文字列で判定する。）
+        for msg in _daemon_messages(caplog):
+            assert "listening on" not in msg
+            assert "127.0.0.1:" not in msg
 
 
 class TestEnsureDaemonLogger:
@@ -114,9 +139,6 @@ def test_appconfig_output_base_dir_used_in_log(
             logger,
             source_description="defaults",
             output_base_dir=output.base_dir,
-            port=9000,
         )
 
-    assert any(
-        f"output base_dir: {tmp_path / 'custom-out'}" == r.getMessage() for r in caplog.records
-    )
+    assert f"output base_dir: {tmp_path / 'custom-out'}" in _daemon_messages(caplog)

--- a/tests/test_daemon_cli.py
+++ b/tests/test_daemon_cli.py
@@ -3,9 +3,12 @@
 import logging
 from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from typer.testing import CliRunner
 
+from meeting_minutes.cli import app
 from meeting_minutes.config import OutputConfig
 from meeting_minutes.daemon import cli as daemon_cli
 
@@ -142,3 +145,40 @@ def test_appconfig_output_base_dir_used_in_log(
         )
 
     assert f"output base_dir: {tmp_path / 'custom-out'}" in _daemon_messages(caplog)
+
+
+class TestDaemonServeCommand:
+    """`daemon serve` の起動経路を結合的に検証する。
+
+    `_log_daemon_startup` 単体テストだけでは「ログ呼び出しが消える」「uvicorn より
+    後にログを出してしまう」といった配線ミスを拾えないため、CLI 経由で uvicorn を
+    モックして起動順序と引数を検証する。
+    """
+
+    def test_logs_config_and_output_then_calls_uvicorn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_dir = tmp_path / "config" / "meeting-minutes"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.toml").touch()
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+        # 起動ログは StreamHandler 経由で stderr に出る（_ensure_daemon_logger が
+        # propagate=False を立てるため caplog では拾えない）。Click 8.3+ の CliRunner は
+        # 既定で stderr を独立ストリームに退避するので result.stderr で取り出して検証する。
+        runner = CliRunner()
+        with patch("uvicorn.run") as uvicorn_run:
+            result = runner.invoke(app, ["daemon", "serve", "--port", "9001"])
+
+        assert result.exit_code == 0, result.output
+        # uvicorn.run が 127.0.0.1:9001 で呼ばれたか
+        uvicorn_run.assert_called_once()
+        kwargs = uvicorn_run.call_args.kwargs
+        assert kwargs["host"] == "127.0.0.1"
+        assert kwargs["port"] == 9001
+        # ログ 2 行を出してから uvicorn を起動している
+        assert "INFO: config source: auto_discovered (" in result.stderr
+        assert "INFO: output base_dir: " in result.stderr
+        # listening 行は CLI からは出さない（uvicorn 自身に委譲）
+        assert "listening on" not in result.stderr

--- a/tests/test_daemon_cli.py
+++ b/tests/test_daemon_cli.py
@@ -158,17 +158,26 @@ class TestDaemonServeCommand:
     def test_logs_config_and_output_then_calls_uvicorn(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        import sys
+
         config_dir = tmp_path / "config" / "meeting-minutes"
         config_dir.mkdir(parents=True)
         (config_dir / "config.toml").touch()
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
 
+        # uvicorn.run の呼び出し時点で stderr にマーカーを書き込み、その前後で
+        # daemon ログの出現位置を比較することで「ログ → uvicorn.run」の順序を
+        # 厳密に保証する（呼び出しの有無だけ assert したのでは、実装が
+        # uvicorn.run の後にログを出してもテストが通ってしまうため）。
+        def fake_uvicorn_run(*_args: object, **_kwargs: object) -> None:
+            sys.stderr.write("__UVICORN_RUN_CALLED__\n")
+
         # 起動ログは StreamHandler 経由で stderr に出る（_ensure_daemon_logger が
         # propagate=False を立てるため caplog では拾えない）。Click 8.3+ の CliRunner は
         # 既定で stderr を独立ストリームに退避するので result.stderr で取り出して検証する。
         runner = CliRunner()
-        with patch("uvicorn.run") as uvicorn_run:
+        with patch("uvicorn.run", side_effect=fake_uvicorn_run) as uvicorn_run:
             result = runner.invoke(app, ["daemon", "serve", "--port", "9001"])
 
         assert result.exit_code == 0, result.output
@@ -177,8 +186,13 @@ class TestDaemonServeCommand:
         kwargs = uvicorn_run.call_args.kwargs
         assert kwargs["host"] == "127.0.0.1"
         assert kwargs["port"] == 9001
-        # ログ 2 行を出してから uvicorn を起動している
-        assert "INFO: config source: auto_discovered (" in result.stderr
-        assert "INFO: output base_dir: " in result.stderr
+        # ログ 2 行が現れ、いずれもマーカー（uvicorn.run 呼び出し時点）より前にある
+        stderr = result.stderr
+        marker_pos = stderr.find("__UVICORN_RUN_CALLED__")
+        config_pos = stderr.find("INFO: config source: auto_discovered (")
+        output_pos = stderr.find("INFO: output base_dir: ")
+        assert marker_pos != -1
+        assert 0 <= config_pos < marker_pos
+        assert 0 <= output_pos < marker_pos
         # listening 行は CLI からは出さない（uvicorn 自身に委譲）
-        assert "listening on" not in result.stderr
+        assert "listening on" not in stderr

--- a/uv.lock
+++ b/uv.lock
@@ -398,6 +398,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "rich" },
     { name = "sounddevice" },
+    { name = "tomli-w" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -412,6 +413,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.2.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "sounddevice", specifier = ">=0.4.6" },
+    { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.29.0" },
 ]
@@ -799,6 +801,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263 },
     { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223 },
     { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127 },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `meeting-minutes config init/path/show/edit` の 4 サブコマンドを追加し、設定ファイルの初期化・参照先確認・閲覧・編集を CLI で完結させる
- `daemon serve` 起動時に `config source` と `output base_dir` を INFO ログに出力する（auto_discovery / explicit / defaults を区別）。待ち受けアドレスは uvicorn 自身が出す `Uvicorn running on http://...` で確認できる
- `config.py` を `config/` サブパッケージへ再編し、`config.example.toml` を `src/meeting_minutes/config/templates/` に移してパッケージデータとして同梱（`uv tool install .` 後の wheel でも `config init` が雛形を解決できる）
- 同梱テンプレートの `[output] base_dir` をコメントアウトし、`config init` 直後は XDG 既定 (`$XDG_DATA_HOME/meeting-minutes/output/`) に出力されるようにする

#38 で挙げられていた対応案 1（CLI）と 2（daemon ログ）に対応。対応案 3（daemon の `GET/PUT /config`）は将来の Web UI 議論（#14）に切り出し、本 PR ではスコープ外。

## 起動ログの仕様について

issue #38 の対応案では 3 行目に `listening on http://127.0.0.1:8765` を出す案だったが、実装では削除した。理由:

- uvicorn 自身が起動シーケンスの最終段で `Uvicorn running on http://127.0.0.1:8765 (Press CTRL+C to quit)` を出力している
- 自前で先に `listening on ...` を出すと、ポート衝突などで実際には bind に失敗したケースでも「listening している」かのような表示が残り、誤認の原因になる

config / output base_dir の 2 行は uvicorn の起動より前に出るので、どの設定で動いているかは最初の数行で把握できる。

## 主な変更

- `src/meeting_minutes/config/__init__.py`: `ConfigSource` / `resolve_config_source` / `read_template_config_text` を追加
- `src/meeting_minutes/config/cli.py`: 新規。`config_app` Typer グループと 4 つのサブコマンド、`describe_config_source` ヘルパー
- `src/meeting_minutes/config/templates/config.example.toml`: パッケージデータ。`[output] base_dir` はコメントアウト済み
- `src/meeting_minutes/daemon/cli.py`: serve 起動時に `_log_daemon_startup` で 2 行の INFO ログを uvicorn より先に出す
- `pyproject.toml`: `tomli-w` を依存追加（`config show --format toml` 用）
- ドキュメント (`README.md`, `docs/cli.md`, `AGENTS.md`): `config` サブコマンドと daemon 起動ログの説明、雛形パスの更新

## Test plan

- [x] `just check` (ruff format/check + mypy + pytest, 181 passed)
- [x] `meeting-minutes config init` で `~/.config/meeting-minutes/config.toml` が生成される（既存ファイルは `--force` 必須、対象が dir なら明示的にエラー）
- [x] `meeting-minutes config path` が `explicit` / `auto_discovered` / `defaults` を切り分けて表示
- [x] `meeting-minutes config show --format {toml,json}` が解決後の `AppConfig` を出力（JSON は `null` を保持、TOML は除外）
- [x] `meeting-minutes config edit` / `--config <path>` が `$EDITOR` を起動し、未設定時は macOS の `open(1)` にフォールバック
- [x] `daemon serve` 起動時に config / output base_dir の INFO ログを出してから `uvicorn.run` を呼ぶことを CliRunner + uvicorn.run モックで検証
- [x] `uv build` で `config.example.toml` が wheel に同梱されることを確認

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)