### PR TITLE
feat: show whisper model download progress

### DIFF
--- a/src/meeting_minutes/transcription/live.py
+++ b/src/meeting_minutes/transcription/live.py
@@ -269,6 +269,7 @@ def run_live(
         init_transcript(transcript_path, config, input_device, started_at)
 
     console.print(f"[green]Recording:[/green] {input_device.name} [{input_device.index}]")
+    console.print(f"[green]Whisper model:[/green] {config.transcription.whisper_model}")
     console.print(f"[green]Output:[/green] {session_dir}")
     console.print("Press Ctrl+C to stop.")
 

--- a/src/meeting_minutes/transcription/transcribe.py
+++ b/src/meeting_minutes/transcription/transcribe.py
@@ -125,10 +125,7 @@ def _snapshot_download(repo_id: str, *, allow_patterns: list[str]) -> str:
 
 def _is_path_like_model(model: str) -> bool:
     return (
-        model.startswith(("~", "."))
-        or Path(model).is_absolute()
-        or "/" in model
-        or "\\" in model
+        model.startswith(("~", ".")) or Path(model).is_absolute() or "/" in model or "\\" in model
     )
 
 

--- a/src/meeting_minutes/transcription/transcribe.py
+++ b/src/meeting_minutes/transcription/transcribe.py
@@ -88,7 +88,7 @@ def _ensure_model_available(model: str) -> str:
 
     from faster_whisper.transcribe import download_model  # type: ignore[import-untyped]
 
-    model_repos = cast(dict[str, str], download_model.__globals__["_MODELS"])
+    model_repos = _model_repos(download_model.__globals__.get("_MODELS"))
     repo_id = model if "/" in model else model_repos.get(model)
     if repo_id is None:
         raise ValueError(
@@ -105,3 +105,11 @@ def _ensure_model_available(model: str) -> str:
             "vocabulary.*",
         ],
     )
+
+
+def _model_repos(value: object) -> dict[str, str]:
+    if not isinstance(value, dict) or not all(
+        isinstance(key, str) and isinstance(repo_id, str) for key, repo_id in value.items()
+    ):
+        raise ValueError("faster-whisper model mapping is unavailable")
+    return cast(dict[str, str], value)

--- a/src/meeting_minutes/transcription/transcribe.py
+++ b/src/meeting_minutes/transcription/transcribe.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import cast
 
 import numpy as np
-from huggingface_hub import snapshot_download
 
 from meeting_minutes.config import TranscriptionConfig
 from meeting_minutes.errors import TranscriptionError
@@ -89,12 +88,23 @@ def _ensure_model_available(model: str) -> str:
 
     from faster_whisper.transcribe import download_model  # type: ignore[import-untyped]
 
-    model_repos = _model_repos(download_model.__globals__.get("_MODELS"))
+    try:
+        model_repos = _model_repos(download_model.__globals__.get("_MODELS"))
+    except ValueError:
+        return model
+
     repo_id = model_repos.get(model)
     if repo_id is None:
         return model
 
-    return snapshot_download(
+    try:
+        return _download_model_snapshot(repo_id)
+    except Exception as exc:
+        raise ValueError(f"Whisperモデルをダウンロードできませんでした: {exc}") from exc
+
+
+def _download_model_snapshot(repo_id: str) -> str:
+    return _snapshot_download(
         repo_id,
         allow_patterns=[
             "config.json",
@@ -104,6 +114,12 @@ def _ensure_model_available(model: str) -> str:
             "vocabulary.*",
         ],
     )
+
+
+def _snapshot_download(repo_id: str, *, allow_patterns: list[str]) -> str:
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(repo_id, allow_patterns=allow_patterns)
 
 
 def _model_repos(value: object) -> dict[str, str]:

--- a/src/meeting_minutes/transcription/transcribe.py
+++ b/src/meeting_minutes/transcription/transcribe.py
@@ -82,18 +82,19 @@ class WhisperTranscriber:
 
 def _ensure_model_available(model: str) -> str:
     """Download named Hugging Face models with progress before faster-whisper loads them."""
-    model_path = Path(model).expanduser()
-    if model_path.exists():
-        return str(model_path)
-
     from faster_whisper.transcribe import download_model  # type: ignore[import-untyped]
 
     try:
         model_repos = _model_repos(download_model.__globals__.get("_MODELS"))
     except ValueError:
-        return model
+        model_repos = {}
 
     repo_id = model_repos.get(model)
+    if repo_id is None and _is_path_like_model(model):
+        model_path = Path(model).expanduser()
+        if model_path.exists():
+            return str(model_path)
+
     if repo_id is None:
         return model
 
@@ -120,6 +121,15 @@ def _snapshot_download(repo_id: str, *, allow_patterns: list[str]) -> str:
     from huggingface_hub import snapshot_download
 
     return snapshot_download(repo_id, allow_patterns=allow_patterns)
+
+
+def _is_path_like_model(model: str) -> bool:
+    return (
+        model.startswith(("~", "."))
+        or Path(model).is_absolute()
+        or "/" in model
+        or "\\" in model
+    )
 
 
 def _model_repos(value: object) -> dict[str, str]:

--- a/src/meeting_minutes/transcription/transcribe.py
+++ b/src/meeting_minutes/transcription/transcribe.py
@@ -1,8 +1,11 @@
 """faster-whisper を用いた音声書き起こしのラッパー。"""
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
 
 import numpy as np
+from huggingface_hub import snapshot_download
 
 from meeting_minutes.config import TranscriptionConfig
 from meeting_minutes.errors import TranscriptionError
@@ -29,8 +32,9 @@ class WhisperTranscriber:
         try:
             from faster_whisper import WhisperModel
 
+            model_path = _ensure_model_available(config.whisper_model)
             self._model = WhisperModel(
-                config.whisper_model,
+                model_path,
                 device=config.device,
                 compute_type=config.compute_type,
             )
@@ -75,3 +79,29 @@ class WhisperTranscriber:
         except (RuntimeError, ValueError) as exc:
             raise TranscriptionError(f"文字起こしに失敗しました: {exc}") from exc
         return results
+
+
+def _ensure_model_available(model: str) -> str:
+    """Download named Hugging Face models with progress before faster-whisper loads them."""
+    if Path(model).exists():
+        return model
+
+    from faster_whisper.transcribe import download_model  # type: ignore[import-untyped]
+
+    model_repos = cast(dict[str, str], download_model.__globals__["_MODELS"])
+    repo_id = model if "/" in model else model_repos.get(model)
+    if repo_id is None:
+        raise ValueError(
+            f"Invalid model size '{model}', expected one of: {', '.join(model_repos.keys())}"
+        )
+
+    return snapshot_download(
+        repo_id,
+        allow_patterns=[
+            "config.json",
+            "preprocessor_config.json",
+            "model.bin",
+            "tokenizer.json",
+            "vocabulary.*",
+        ],
+    )

--- a/src/meeting_minutes/transcription/transcribe.py
+++ b/src/meeting_minutes/transcription/transcribe.py
@@ -83,17 +83,16 @@ class WhisperTranscriber:
 
 def _ensure_model_available(model: str) -> str:
     """Download named Hugging Face models with progress before faster-whisper loads them."""
-    if Path(model).exists():
-        return model
+    model_path = Path(model).expanduser()
+    if model_path.exists():
+        return str(model_path)
 
     from faster_whisper.transcribe import download_model  # type: ignore[import-untyped]
 
     model_repos = _model_repos(download_model.__globals__.get("_MODELS"))
-    repo_id = model if "/" in model else model_repos.get(model)
+    repo_id = model_repos.get(model)
     if repo_id is None:
-        raise ValueError(
-            f"Invalid model size '{model}', expected one of: {', '.join(model_repos.keys())}"
-        )
+        return model
 
     return snapshot_download(
         repo_id,

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -120,6 +120,16 @@ def test_run_live_writes_audio_and_transcript(
     assert audio_path.stat().st_size > 44
 
 
+def test_run_live_prints_whisper_model(
+    tmp_path: Path,
+    live_dependencies: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    run_live(live_config(tmp_path))
+
+    assert "Whisper model: small" in capsys.readouterr().out
+
+
 def test_run_live_applies_preprocessing_before_transcription(
     tmp_path: Path,
     input_device: InputDevice,

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -97,6 +97,18 @@ def test_ensure_model_available_returns_existing_local_path(tmp_path: Path) -> N
     assert transcribe._ensure_model_available(str(model_dir)) == str(model_dir)
 
 
+def test_ensure_model_available_expands_existing_home_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    model_dir = home_dir / "local-model"
+    model_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    assert transcribe._ensure_model_available("~/local-model") == str(model_dir)
+
+
 def test_ensure_model_available_downloads_named_model(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
@@ -110,6 +122,21 @@ def test_ensure_model_available_downloads_named_model(monkeypatch: pytest.Monkey
     assert calls[0][0] == "Systran/faster-whisper-small"
     allow_patterns = cast(list[str], calls[0][1]["allow_patterns"])
     assert "model.bin" in allow_patterns
+
+
+def test_ensure_model_available_leaves_unknown_path_like_model_to_faster_whisper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_snapshot_download(repo_id: str, **_kwargs: object) -> str:
+        calls.append(repo_id)
+        return "/cache/model"
+
+    monkeypatch.setattr(transcribe, "snapshot_download", fake_snapshot_download)
+
+    assert transcribe._ensure_model_available("models/whisper-small") == "models/whisper-small"
+    assert calls == []
 
 
 def test_model_repos_rejects_missing_private_mapping() -> None:

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -110,3 +110,8 @@ def test_ensure_model_available_downloads_named_model(monkeypatch: pytest.Monkey
     assert calls[0][0] == "Systran/faster-whisper-small"
     allow_patterns = cast(list[str], calls[0][1]["allow_patterns"])
     assert "model.bin" in allow_patterns
+
+
+def test_model_repos_rejects_missing_private_mapping() -> None:
+    with pytest.raises(ValueError, match="model mapping is unavailable"):
+        transcribe._model_repos(None)

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -110,16 +110,29 @@ def test_ensure_model_available_expands_existing_home_path(
 
 
 def test_ensure_model_available_downloads_named_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_download_model_snapshot(repo_id: str) -> str:
+        calls.append(repo_id)
+        return "/cache/small"
+
+    monkeypatch.setattr(transcribe, "_model_repos", lambda _value: {"small": "example/small"})
+    monkeypatch.setattr(transcribe, "_download_model_snapshot", fake_download_model_snapshot)
+
+    assert transcribe._ensure_model_available("small") == "/cache/small"
+    assert calls == ["example/small"]
+
+
+def test_download_model_snapshot_limits_downloaded_files(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, dict[str, object]]] = []
 
     def fake_snapshot_download(repo_id: str, **kwargs: object) -> str:
         calls.append((repo_id, kwargs))
         return "/cache/small"
 
-    monkeypatch.setattr(transcribe, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(transcribe, "_snapshot_download", fake_snapshot_download)
 
-    assert transcribe._ensure_model_available("small") == "/cache/small"
-    assert calls[0][0] == "Systran/faster-whisper-small"
+    assert transcribe._download_model_snapshot("example/small") == "/cache/small"
     allow_patterns = cast(list[str], calls[0][1]["allow_patterns"])
     assert "model.bin" in allow_patterns
 
@@ -133,10 +146,42 @@ def test_ensure_model_available_leaves_unknown_path_like_model_to_faster_whisper
         calls.append(repo_id)
         return "/cache/model"
 
-    monkeypatch.setattr(transcribe, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(transcribe, "_download_model_snapshot", fake_snapshot_download)
 
     assert transcribe._ensure_model_available("models/whisper-small") == "models/whisper-small"
     assert calls == []
+
+
+def test_ensure_model_available_falls_back_when_model_mapping_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_download_model_snapshot(repo_id: str) -> str:
+        calls.append(repo_id)
+        return "/cache/model"
+
+    def fake_model_repos(_value: object) -> dict[str, str]:
+        raise ValueError("missing mapping")
+
+    monkeypatch.setattr(transcribe, "_model_repos", fake_model_repos)
+    monkeypatch.setattr(transcribe, "_download_model_snapshot", fake_download_model_snapshot)
+
+    assert transcribe._ensure_model_available("small") == "small"
+    assert calls == []
+
+
+def test_ensure_model_available_wraps_download_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_download_model_snapshot(_repo_id: str) -> str:
+        raise RuntimeError("network unavailable")
+
+    monkeypatch.setattr(transcribe, "_model_repos", lambda _value: {"small": "example/small"})
+    monkeypatch.setattr(transcribe, "_download_model_snapshot", fake_download_model_snapshot)
+
+    with pytest.raises(ValueError, match="ダウンロードできませんでした"):
+        transcribe._ensure_model_available("small")
 
 
 def test_model_repos_rejects_missing_private_mapping() -> None:

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+from typing import cast
+
 import numpy as np
+import pytest
 
 from meeting_minutes.config import TranscriptionConfig
+from meeting_minutes.transcription import transcribe
 from meeting_minutes.transcription.transcribe import WhisperTranscriber
 
 
@@ -83,3 +88,25 @@ def test_transcribe_segments_accepts_per_call_initial_prompt() -> None:
     )
 
     assert fake_model.last_kwargs["initial_prompt"] == "参加者: 鈴木"
+
+
+def test_ensure_model_available_returns_existing_local_path(tmp_path: Path) -> None:
+    model_dir = tmp_path / "local-model"
+    model_dir.mkdir()
+
+    assert transcribe._ensure_model_available(str(model_dir)) == str(model_dir)
+
+
+def test_ensure_model_available_downloads_named_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_snapshot_download(repo_id: str, **kwargs: object) -> str:
+        calls.append((repo_id, kwargs))
+        return "/cache/small"
+
+    monkeypatch.setattr(transcribe, "snapshot_download", fake_snapshot_download)
+
+    assert transcribe._ensure_model_available("small") == "/cache/small"
+    assert calls[0][0] == "Systran/faster-whisper-small"
+    allow_patterns = cast(list[str], calls[0][1]["allow_patterns"])
+    assert "model.bin" in allow_patterns

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -109,6 +109,25 @@ def test_ensure_model_available_expands_existing_home_path(
     assert transcribe._ensure_model_available("~/local-model") == str(model_dir)
 
 
+def test_ensure_model_available_prefers_known_model_over_same_named_local_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "small").mkdir()
+    calls: list[str] = []
+
+    def fake_download_model_snapshot(repo_id: str) -> str:
+        calls.append(repo_id)
+        return "/cache/small"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(transcribe, "_model_repos", lambda _value: {"small": "example/small"})
+    monkeypatch.setattr(transcribe, "_download_model_snapshot", fake_download_model_snapshot)
+
+    assert transcribe._ensure_model_available("small") == "/cache/small"
+    assert calls == ["example/small"]
+
+
 def test_ensure_model_available_downloads_named_model(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
## Summary
- Show the configured Whisper model when starting live transcription.
- Pre-download named faster-whisper models through Hugging Face Hub so initial model downloads show progress.
- Add regression tests for model display and model download path resolution.

## Tests
- uv run ruff check src tests
- uv run mypy src tests
- uv run pytest tests/test_transcribe.py tests/test_live.py