### PR TITLE
PR/Issueテンプレート追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,66 @@
+name: Bug
+description: Track a concrete defect in the author's local meeting-minutes workflow.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This repository is public, but `meeting-minutes` is a personal local macOS tool.
+        Issues are for tracking defects in the author's own workflow, not for general support requests.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What failed, and what were you trying to do?
+      placeholder: "Example: `meeting-minutes live` stopped after ..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Minimal local steps, commands, and config details needed to reproduce.
+      placeholder: |
+        1. Run `...`
+        2. Use config `...`
+        3. Observe `...`
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen for the author's local workflow?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: Include the relevant traceback, CLI output, or log excerpt.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Local Environment
+      description: Include only details that matter for this failure.
+      value: |
+        - macOS:
+        - Python:
+        - Audio device:
+        - Ollama model:
+        - Command:
+    validations:
+      required: false
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Project Boundaries
+      options:
+        - label: This is not a request for general support or a feature for other users.
+          required: true
+        - label: The issue can be reproduced without live audio hardware or a running Ollama server, or those dependencies are explicitly called out above.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Fork this project
+    url: https://github.com/kk6/meeting-minutes/fork
+    about: This project is a personal local tool. External support and feature requests are not handled through Issues.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,51 @@
+name: Task
+description: Track a planned change for the author's local workflow.
+title: "[task] "
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for work the author actually wants in their local setup.
+        This project intentionally avoids general-purpose product requirements.
+  - type: textarea
+    id: intent
+    attributes:
+      label: Intent
+      description: What should improve in the author's actual workflow?
+      placeholder: "Example: make Raycast stop/start smoother when ..."
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What files, commands, or behavior are likely involved?
+      placeholder: |
+        - CLI command:
+        - Config:
+        - Output/session artifact:
+        - Docs/tests:
+    validations:
+      required: false
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-Goals
+      description: What should remain out of scope?
+      value: |
+        - General support for other users
+        - Multi-user or remote-host operation
+        - Cloud transcription or summarization APIs
+    validations:
+      required: false
+  - type: textarea
+    id: checks
+    attributes:
+      label: Verification
+      description: How should this be checked locally?
+      value: |
+        - [ ] `just check`
+        - [ ] Manual CLI smoke check:
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What changed, and why? Keep this focused on the author's local workflow. -->
+
+## Scope
+
+- [ ] CLI behavior
+- [ ] Daemon/API behavior
+- [ ] Transcription/audio pipeline
+- [ ] Minutes generation/Ollama prompts
+- [ ] Config/output format
+- [ ] Documentation or examples
+- [ ] Tests/tooling only
+
+## Local Checks
+
+<!-- Mark what was run. Leave unchecked if not relevant. -->
+
+- [ ] `just check`
+- [ ] `just check-lint`
+- [ ] `just test`
+- [ ] Manual smoke check:
+
+## Notes
+
+<!--
+This is a personal local macOS tool. Avoid adding general product surface, remote
+connectivity, multi-user behavior, broad compatibility work, or cloud APIs unless
+the change directly supports the author's workflow.
+-->


### PR DESCRIPTION
## Summary

Add GitHub templates that match this repository's stance as a personal local macOS tool.

This adds:

- A pull request template with focused scope and local check sections
- A `Bug` issue form for concrete defects in the author's local workflow
- A `Task` issue form for planned local workflow changes
- Issue template config that disables blank issues and points external users toward forking instead of filing support requests

## Scope

- [ ] CLI behavior
- [ ] Daemon/API behavior
- [ ] Transcription/audio pipeline
- [ ] Minutes generation/Ollama prompts
- [ ] Config/output format
- [x] Documentation or examples
- [x] Tests/tooling only

## Local Checks

- [ ] `just check`
- [ ] `just check-lint`
- [ ] `just test`
- [ ] Manual smoke check:

Runtime checks were not run because this change only adds GitHub metadata templates. The commit hook ran on commit; ruff, ruff-format, and mypy were skipped because no checked code files changed.

## Notes

The templates intentionally reflect the README/AGENTS.md project boundary: this is a public repository for a personal local macOS tool, not a supported general-purpose product. The Issue forms are therefore scoped to the author's own bug/task tracking rather than general support or feature requests.
